### PR TITLE
Update README to reflect current repo layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Personal reference repo — notes, scripts, skills, and templates I reach for re
 | Directory | What's in it |
 |-----------|-------------|
 | `agentic-ai/` | Notes on agentic AI modules and patterns |
-| `claude-skills/` | Custom Claude Code skills (image editing, etc.) |
 | `courses-notes/` | Course notes (DeepLearning.ai Claude Code course, etc.) |
 | `dev-tips/` | Dev tips and cheatsheets (Claude Code, uv, tools) |
 | `llms/` | LLM implementation notebooks (RoPE, SwiGLU) |
 | `modal/` | Modal scripts (tokenization, data processing) |
 | `opencv-dip/` | OpenCV and digital image processing tutorials |
 | `prompt-library/` | Reusable prompts and prompt templates |
+| `reading-list/` | Structured reading list (papers, tech-reports, blogs, books, tools) with YAML frontmatter |
 | `reading-links/` | Curated reading lists (RL, tech reports) |
 | `rulesets/` | GitHub branch protection rules |
 
-Standalone files: `starred-repos.md`
+Standalone files: `starred-repos.md`, `blogs_papers_summaries.md`, `Notes_DeepseekMath-R1.md`


### PR DESCRIPTION
## Summary
- Remove `claude-skills/` row (skills now live under `.claude/skills/`)
- Add `reading-list/` row (structured reading list with YAML frontmatter)
- Add `blogs_papers_summaries.md` and `Notes_DeepseekMath-R1.md` to standalone files

## Test plan
- [x] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)