### PR TITLE
[codex] add Claude planning skills

### DIFF
--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: grill-me
+description: Stress-test an existing implementation plan. Use when the user has a concrete plan and wants it challenged — finding holes, questioning assumptions, probing edge cases, and resolving each branch of the decision tree.
+---
+
+I have an implementation plan. Your job is to stress-test it relentlessly.
+
+Challenge my assumptions. Find holes. Probe edge cases and failure modes. Question every architectural decision. Walk down each branch of the decision tree, resolving dependencies between decisions one-by-one.
+
+For each question, give me your recommended answer and your reasoning.
+
+Ask one question at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead of asking.
+
+Your goal is not to understand what I say I want — it is to be 95% confident you understand what I actually want and whether this plan truly serves it. Keep grilling until you reach that bar.

--- a/.claude/skills/interview-me/SKILL.md
+++ b/.claude/skills/interview-me/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: interview-me
+description: Interview the user to uncover intent and goals for a new idea. Use when the user is exploring something new and wants to think it through before implementation.
+---
+
+I have an idea I want to explore. Your job is to interview me until you fully understand it. Your goal is to be 95% confident you understand what I actually want — not what I say I want.


### PR DESCRIPTION
## Summary

Adds two Claude skills under `.claude/skills`:

- `grill-me`: stress-tests concrete implementation plans by challenging assumptions and edge cases.
- `interview-me`: interviews the user to clarify intent and goals for a new idea before implementation.

## Validation

- Verified the PR diff contains only the two new skill files.
- Created one commit per skill as requested.