### PR TITLE
Scrub hardcoded home path from iTerm2 prefs

### DIFF
--- a/setup-scripts/terminal/com.googlecode.iterm2.plist
+++ b/setup-scripts/terminal/com.googlecode.iterm2.plist
@@ -1554,7 +1554,7 @@ The script should do this: \(ai.prompt)</string>
 			<key>Window Type</key>
 			<integer>0</integer>
 			<key>Working Directory</key>
-			<string>/Users/aayushgarg</string>
+			<string>~</string>
 		</dict>
 	</array>
 	<key>PointerActions</key>


### PR DESCRIPTION
Replaces `Working Directory = /Users/aayushgarg` with `~` in the exported iTerm2 prefs.

`Custom Directory = No` means iTerm2 ignores the Working Directory value (it opens in `$HOME`), so this is functionally a no-op — it just avoids publishing a username in the public repo. Verified: `plutil -lint` passes; no `aayush` strings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)