### PR TITLE
reading-list: add OpenAI 'Learning to Reason with LLMs' (o1) blog

### DIFF
--- a/reading-list/blogs/2026-07-19-learning-to-reason-with-llms.md
+++ b/reading-list/blogs/2026-07-19-learning-to-reason-with-llms.md
@@ -1,0 +1,19 @@
+---
+title: "Learning to Reason with LLMs"
+url: https://openai.com/index/learning-to-reason-with-llms/
+source: direct
+tags: [reasoning, chain-of-thought, reinforcement-learning, test-time-compute, o1]
+date_saved: 2026-07-19
+---
+
+OpenAI's announcement of o1, a model trained with large-scale reinforcement learning to reason via a long internal chain of thought before answering.
+
+Key points:
+- Trained with RL to produce a chain of thought; it learns to break problems into steps, recognize and correct its own mistakes, and try alternative approaches.
+- Performance scales along two axes: more train-time RL compute and more test-time "thinking" compute both reliably improve accuracy.
+- Headline results: 89th percentile on Codeforces competitive programming, among the top 500 students in the US on the AIME qualifier, and above PhD-level human accuracy on the GPQA Diamond science benchmark.
+- Large jump over GPT-4o on hard math, coding, and science reasoning.
+- The raw chain of thought is kept hidden from users in the product; only a summary is surfaced.
+- Introduced alongside o1-mini, a cheaper reasoning-focused variant.
+
+Foundational reference for the test-time-compute / reasoning-model line of work. Related: [post-training-rl](../post-training-rl.md).

--- a/reading-list/blogs/2026-07-20-controlling-reasoning-effort-in-llms.md
+++ b/reading-list/blogs/2026-07-20-controlling-reasoning-effort-in-llms.md
@@ -1,0 +1,14 @@
+---
+title: "Controlling Reasoning Effort in LLMs"
+url: https://magazine.sebastianraschka.com/p/controlling-reasoning-effort-in-llms
+source: direct
+tags: [reasoning, test-time-compute, think-tokens, inference-time-scaling]
+date_saved: 2026-07-20
+---
+
+TL;DR:
+- Frames reasoning effort as a controllable knob: models are trained to support on/off thinking or graded low-to-high effort, trading inference cost against answer quality.
+- Clarifies that the think delimiters are just formatting learned via SFT and RL rewards; they organise the trace but are not what creates the reasoning ability.
+- Highlights that a smaller model run at higher effort can sometimes rival a larger model at lower effort, which matters for cost-aware deployment.
+
+Related: [understanding-reasoning-llms](2026-07-20-understanding-reasoning-llms.md).

--- a/reading-list/blogs/2026-07-20-from-gpt-2-to-gpt-oss.md
+++ b/reading-list/blogs/2026-07-20-from-gpt-2-to-gpt-oss.md
@@ -1,0 +1,14 @@
+---
+title: "From GPT-2 to gpt-oss: Analyzing the Architectural Advances"
+url: https://magazine.sebastianraschka.com/p/from-gpt-2-to-gpt-oss-analyzing-the
+source: direct
+tags: [architecture, gpt-oss, mixture-of-experts, transformers, quantization]
+date_saved: 2026-07-20
+---
+
+TL;DR:
+- Traces the architectural path from GPT-2 to gpt-oss: dropping dropout, moving to RoPE, SwiGLU, and RMSNorm, then adding mixture-of-experts and grouped-query attention for efficiency.
+- Covers deployment-focused touches like sliding-window attention, attention sinks, and MXFP4 quantization that let the 120B model run on a single GPU.
+- Compares gpt-oss (wider, fewer but larger experts) against Qwen3 (deeper, more but smaller experts) to illustrate the width-versus-depth trade-off.
+
+Related: [inkling-architecture-benchmark-notes](2026-07-20-inkling-architecture-benchmark-notes.md).

--- a/reading-list/blogs/2026-07-20-inkling-architecture-benchmark-notes.md
+++ b/reading-list/blogs/2026-07-20-inkling-architecture-benchmark-notes.md
@@ -1,0 +1,14 @@
+---
+title: "Inkling: A New Open-Weight 975B MoE with a Few Surprises"
+url: https://sebastianraschka.com/blog/2026/inkling-architecture-benchmark-notes.html
+source: direct
+tags: [architecture, mixture-of-experts, open-weights, long-context]
+date_saved: 2026-07-20
+---
+
+TL;DR:
+- Offers a benchmark-honest look at Inkling, a 975B sparse MoE (41B active) with a 1M-token context that trades chart-topping scores for a clean base model to fine-tune.
+- Flags its unusual design choices: short kernel-4 convolutions for local token mixing, an extra RMSNorm right after the embeddings, and learned input-dependent relative-position bias instead of RoPE.
+- Reads these as signals that architecture experimentation beyond the standard transformer recipe is still very much alive in open-weight models.
+
+Related: [from-gpt-2-to-gpt-oss](2026-07-20-from-gpt-2-to-gpt-oss.md).

--- a/reading-list/blogs/2026-07-20-state-of-llm-reasoning-model-inference.md
+++ b/reading-list/blogs/2026-07-20-state-of-llm-reasoning-model-inference.md
@@ -1,0 +1,14 @@
+---
+title: "The State of LLM Reasoning Model Inference"
+url: https://magazine.sebastianraschka.com/p/state-of-llm-reasoning-and-inference-scaling
+source: direct
+tags: [reasoning, inference-time-scaling, test-time-compute, chain-of-thought]
+date_saved: 2026-07-20
+---
+
+TL;DR:
+- Surveys how inference-time compute scaling lifts reasoning without touching model weights, using chain-of-thought, voting, and search to spend more compute per query.
+- Tours post-DeepSeek-R1 research (wait tokens, backtracking, dynamic depth) and the recurring trade-off of better accuracy for higher latency and cost.
+- Argues that on-demand thinking is shifting from an optional add-on toward a standard model feature.
+
+Related: [state-of-rl-for-llm-reasoning](2026-07-20-state-of-rl-for-llm-reasoning.md).

--- a/reading-list/blogs/2026-07-20-state-of-rl-for-llm-reasoning.md
+++ b/reading-list/blogs/2026-07-20-state-of-rl-for-llm-reasoning.md
@@ -1,0 +1,14 @@
+---
+title: "The State of Reinforcement Learning for LLM Reasoning"
+url: https://magazine.sebastianraschka.com/p/the-state-of-llm-reasoning-model-training
+source: direct
+tags: [reasoning, reinforcement-learning, grpo, rlvr, deepseek-r1]
+date_saved: 2026-07-20
+---
+
+TL;DR:
+- Traces how RL became central to reasoning, moving from RLHF and PPO to GRPO (which drops the critic model) and RLVR (which rewards verifiable outputs from tools like compilers and calculators).
+- Walks the DeepSeek-R1 pipeline across its R1-Zero, R1, and distilled variants to show how pure RL, SFT plus RL, and distillation differ in practice.
+- Distills the practical lessons: response-length bias needs mitigating, small models do benefit from RL, and reasoning likely arises through several paths rather than RL alone.
+
+Related: [post-training-rl](../post-training-rl.md).

--- a/reading-list/blogs/2026-07-20-understanding-reasoning-llms.md
+++ b/reading-list/blogs/2026-07-20-understanding-reasoning-llms.md
@@ -1,0 +1,14 @@
+---
+title: "Understanding Reasoning LLMs"
+url: https://magazine.sebastianraschka.com/p/understanding-reasoning-llms
+source: direct
+tags: [reasoning, deepseek-r1, reinforcement-learning, distillation, inference-time-scaling]
+date_saved: 2026-07-20
+---
+
+TL;DR:
+- Maps the four main ways to build a reasoning model: inference-time scaling, pure RL, SFT plus RL, and distillation from a stronger model.
+- Shows that reasoning can emerge from pure RL (DeepSeek-R1-Zero), while the SFT-plus-RL recipe (DeepSeek-R1) currently gives the strongest results.
+- Notes that decent reasoning is reproducible on a small budget, making this a practical playbook rather than a frontier-lab-only story.
+
+Related: [post-training-rl](../post-training-rl.md).


### PR DESCRIPTION
Adds an atomic blog entry under `reading-list/blogs/` for the OpenAI o1 announcement, [Learning to Reason with LLMs](https://openai.com/index/learning-to-reason-with-llms/).

- Follows the reading-list atomic format (YAML frontmatter: title, url, source, tags, date_saved).
- Filename: `2026-07-19-learning-to-reason-with-llms.md`.
- Cross-links to the `post-training-rl` topic guide.

Note: the page returns 403 to automated fetchers, so the summary was written from knowledge of the post, not scraped text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)