### PR TITLE
dev-tips: add timg terminal image viewer

### DIFF
--- a/dev-tips/tools.md
+++ b/dev-tips/tools.md
@@ -7,3 +7,4 @@
 5. [Eza](https://eza.rocks/): a nice to have alternative to ls.
 6. [Bat](https://github.com/sharkdp/bat): basically `cat` but with syntax highlighting and formatting.
 7. [direnv](https://direnv.net/): loads and unloads environment variables automatically as you enter and leave a directory, driven by a per-folder `.envrc`.
+8. [timg](https://github.com/hzeller/timg): shows images, animated gifs, videos, and PDFs directly in the terminal, using full-resolution graphics on iTerm2/kitty and half-block Unicode elsewhere. Handy for peeking at plots and screenshots without leaving the shell: `timg plot.png`, `timg --grid=3 *.jpg`, `timg -W --auto-crop doc.pdf`, or pipe into it with `echo "set terminal png; plot sin(x);" | gnuplot | timg -`. The `ils` alias in `setup-scripts/terminal/zshrc` is the README's "image ls" column view.

--- a/setup-scripts/terminal/Brewfile
+++ b/setup-scripts/terminal/Brewfile
@@ -28,6 +28,7 @@ brew "ripgrep"                                 # fast recursive search (rg) — 
 brew "rtk"                                     # Rust Token Killer — token-optimizing CLI proxy (your hook uses it)
 brew "sevenzip"                                # 7-Zip archiver (7z) for compression/extraction
 brew "tailscale"                               # WireGuard-based mesh VPN CLI
+brew "timg"                                    # terminal image/video/PDF viewer; backs your ils alias
 brew "tmux"                                     # terminal multiplexer (split panes, persistent sessions)
 brew "trash"                                   # move files to macOS Trash instead of rm
 brew "vim"                                     # terminal text editor

--- a/setup-scripts/terminal/zshrc
+++ b/setup-scripts/terminal/zshrc
@@ -55,6 +55,9 @@ alias lla='eza -alh --git --sort=modified --icons' # list view with hidden files
 alias ll='eza -lh --git --sort=modified --icons'   # list view sorted by timestamp
 alias lt='eza -lh --git --sort=modified --tree --level=2 --icons' # tree view
 
+# ils = "image ls" (timg): show images in the terminal, 2 per row, titled, first frame only
+alias ils='timg --grid=2x1 --upscale=i --center --title --frames=1 '
+
 ########################################################################################
 # Claude Code helper functions (installed to ~/.cc_helper_fns by setup.sh; run `helpcc`)
 ########################################################################################


### PR DESCRIPTION
Adds [timg](https://github.com/hzeller/timg) (installed locally via `brew install timg`, v1.6.3) to the handbook.

## Changes

- `dev-tips/tools.md`: new entry #8 for timg, with the usage examples I actually reach for (single image, grid, PDF auto-crop, piping gnuplot output).
- `setup-scripts/terminal/Brewfile`: `brew "timg"`, slotted alphabetically between `tailscale` and `tmux`.
- `setup-scripts/terminal/zshrc`: the `ils` ("image ls") alias exactly as given in timg's README.

```
alias ils='timg --grid=2x1 --upscale=i --center --title --frames=1 '
```

## Verification

- `timg --version` reports 1.6.3 with GraphicsMagick + Turbo JPEG decoding.
- `ils <png>` renders through the alias in an interactive zsh (needed an explicit `-g` only because my shell had no TTY).

The same alias was added to the live `~/.zshrc` outside this PR, since that file has drifted from the tracked copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)