### PR TITLE
Import learning notes from personal docs vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,17 @@ Personal reference repo — notes, scripts, skills, and templates I reach for re
 | `.cursor/` | Cursor slash-commands and deslop rules that mirror the skills |
 | `courses-notes/` | Course notes (Claude Code, Building with the Claude API) |
 | `deprecated/` | Skills kept for smaller open-source models (superseded on frontier models) |
-| `dev-tips/` | Dev tips and cheatsheets (Claude Code, uv, tools) |
+| `dev-tips/` | Dev tips and cheatsheets (Claude Code, uv, tools, GitHub, Cursor) |
 | `llms/` | LLM implementation notebooks (RoPE, SwiGLU) |
+| `ml-guides/` | Long-form modelling study guides (GBM, NAM/TFT) and concept notes |
 | `modal/` | Modal scripts (dataset tokenization) |
 | `opencv-dip/` | OpenCV / digital image processing notebooks |
 | `prompt-library/` | Reusable prompts and prompt templates |
 | `reading-list/` | Structured reading list (papers, tech-reports, blogs, books, tools, topic guides) |
 | `rulesets/` | GitHub branch-protection rules |
 | `setup-scripts/` | New-Mac terminal setup (iTerm2, zsh, Brewfile, dotfiles) |
-| `time-series/` | Time-series analysis code (Kalman filters and smoothing examples) |
+| `time-series/` | Time-series analysis code (Kalman filters, smoothing) and the anomaly-detection guide |
+| `vendors/` | Vendor-platform notes (Databricks) |
 
 Standalone files: `starred-repos.md` (247 starred GitHub repos organized by category).
 

--- a/dev-tips/cursor-settings-transfer.md
+++ b/dev-tips/cursor-settings-transfer.md
@@ -1,0 +1,50 @@
+# Copying Cursor Settings from One Machine to Another
+
+## Source Machine (Linux/Mac)
+
+Export the list of installed extensions:
+```bash
+cursor --list-extensions > extensions.txt
+```
+
+Copy these files from the Cursor config directory:
+- **Linux:** `~/.config/Cursor/User/`
+- **Mac:** `~/Library/Application Support/Cursor/User/`
+
+```bash
+cp ~/.config/Cursor/User/settings.json .       # or Mac path
+cp ~/.config/Cursor/User/keybindings.json .
+```
+
+## Target: Linux/Mac
+
+Copy settings and keybindings to the config directory:
+```bash
+cp settings.json ~/.config/Cursor/User/settings.json
+cp keybindings.json ~/.config/Cursor/User/keybindings.json
+```
+
+Install all extensions:
+```bash
+cat extensions.txt | xargs -L 1 cursor --install-extension
+```
+
+## Target: Windows (Git Bash)
+
+Copy settings and keybindings:
+```bash
+cp settings.json "$APPDATA/Cursor/User/settings.json"
+cp keybindings.json "$APPDATA/Cursor/User/keybindings.json"
+```
+
+Install all extensions:
+```bash
+cat extensions.txt | xargs -L 1 cursor --install-extension
+```
+
+If `cursor` is not in PATH, use the full path:
+```bash
+cat extensions.txt | xargs -L 1 "/c/Users/$USERNAME/AppData/Local/Programs/Cursor/resources/app/bin/cursor.cmd" --install-extension
+```
+
+Restart Cursor after all steps.

--- a/dev-tips/github.md
+++ b/dev-tips/github.md
@@ -1,0 +1,30 @@
+# GitHub
+
+## Check your permissions on a repo
+
+```bash
+gh repo view <org>/<repo> --json viewerPermission
+```
+
+Returns one of: `READ`, `TRIAGE`, `WRITE`, `MAINTAIN`, `ADMIN`.
+
+## Pull request vs draft pull request
+
+Mechanically the same GitHub object. A draft just carries a "not ready to merge" flag that changes a few behaviours.
+
+| | **Draft PR** | **Regular PR** |
+|---|---|---|
+| Merge button | Disabled until marked ready | Enabled (subject to checks/reviews) |
+| Reviewer auto-request | No (CODEOWNERS not pinged) | Yes |
+| Review notifications | Quieter, most "please review" pings skip drafts | Pings reviewers immediately |
+| Visual | Grey "Draft" badge | Green "Open" |
+| `pull_request` workflow | Fires by default, CI **does** run on drafts unless filtered with `if: github.event.pull_request.draft == false` | Always runs |
+| Branch protection gates | Exempt from "ready" gates (still subject to required reviews once converted) | Fully enforced |
+| Convertible | "Mark as draft" ↔ "Ready for review" any time, no state lost | Same |
+
+**Why use a draft:**
+- Want CI feedback on a WIP branch without spamming reviewers
+- Sharing an architectural sketch for early input
+- Stacked PRs where the parent isn't ready yet
+
+**CI gotcha.** A workflow triggered on `pull_request` to `main` with no draft filter runs on draft PRs too. And if the workflow's `push` trigger is scoped to `main` only, then pushing to a feature branch *without* opening a PR runs nothing at all. Opening the draft is what starts CI.

--- a/ml-guides/README.md
+++ b/ml-guides/README.md
@@ -1,0 +1,14 @@
+# ML Guides
+
+Reference notes on modelling topics, organised by concept so you can jump straight to a heading. Unlike `reading-list/` (which points outward) and `llms/` (runnable notebooks), these are self-contained explanations.
+
+| Path | What's in it |
+|------|-------------|
+| `gbm/` | Gradient-boosted trees: decision trees to XGBoost/LightGBM, time-series framing, walk-forward validation, leakage |
+| `nam/` | Neural Additive Models and Temporal Fusion Transformers: interpretable additive structure through to temporal attention |
+| `ai-gateway-vs-router.md` | Trust-boundary distinction between an LLM gateway and an LLM router |
+| `tabular-data.md` | Long vs wide table layouts and when each one hurts |
+
+Related: `time-series/anomaly-detection/` holds the time-series and anomaly-detection guide, kept next to the Kalman filter code it refers to.
+
+Diagrams live in an `images/` folder alongside the guide that references them.

--- a/ml-guides/ai-gateway-vs-router.md
+++ b/ml-guides/ai-gateway-vs-router.md
@@ -1,0 +1,15 @@
+# AI gateway vs router
+
+Both sit between your app and one or more LLM providers. Architecturally they look the same (HTTP proxy in front of model APIs). The difference is **ownership and trust boundary**, not protocol.
+
+| | **Gateway** (Databricks AI Gateway, LiteLLM, Portkey, Kong AI) | **Router** (OpenRouter, etc.) |
+|---|---|---|
+| Who runs it | Your org (self-hosted or managed tenant) | A third-party SaaS aggregator |
+| Primary user | An organization fronting its own LLM usage | An individual / small team wanting many models behind one key |
+| Auth model | Internal teams get internal keys | You hand your card to one vendor; they sub-route |
+| Why use it | Governance, cost attribution, policy, audit, vendor-swap | Convenience, model variety, price arbitrage |
+| Routing logic | Rule-based, ops-controlled (team → model, failover order) | You name the model in the request; they forward it |
+| Data residency | Stays on your tenancy | Lives on the router's servers |
+| Compliance posture | "I can prove no PII left our VPC" | "I trust the router not to leak my prompts" |
+
+**Rule of thumb:** gateway = internal control plane. Router = external aggregator.

--- a/ml-guides/gbm/boosted-trees.md
+++ b/ml-guides/gbm/boosted-trees.md
@@ -1,0 +1,618 @@
+# Gradient Boosted Trees
+
+Reference notes on tree-based models: how single trees, bagging, and gradient boosting work, what XGBoost and LightGBM each do differently, and how to frame a time-series forecasting problem so boosted trees can handle it. Written from a deep learning background, so the analogies run in that direction.
+
+## Tree fundamentals
+
+### Decision trees
+
+A decision tree partitions the feature space by asking a sequence of binary questions, each on a single feature. At each internal node the algorithm picks the feature and threshold that best separates the target values, then recurses on each side. Terminal nodes (leaves) hold a prediction: the mean of all training samples that landed there (regression) or the majority class (classification).
+
+**Key intuition.** A decision tree is a piecewise-constant function. For a reactor yield prediction task, the tree might first split on inlet temperature > 385 °C, then on catalyst age > 45 days. Each leaf represents an operating regime with a single predicted yield. Compare this to a neural network that learns a smooth function: a tree learns a step function.
+
+**Splitting criteria.** For regression, the standard criterion is variance reduction (equivalently, minimising squared error within child nodes). For classification, Gini impurity or entropy. The algorithm evaluates every possible (feature, threshold) pair at each node and picks the one that maximises the reduction in impurity. This is an exhaustive search, expensive on wide data, but the reason trees capture non-linear interactions without feature engineering.
+
+**Depth and prediction.** A depth-1 tree (a "stump") makes one split, essentially a single if-else rule. A depth-10 tree can capture complex interactions but memorises noise. In plant data, a deep tree might learn that "when Tag_A > 200 AND Tag_B < 50 AND it's a Tuesday AND Tag_C is between 7.31 and 7.32… then yield = 91.3" — that last condition is fitting a single data point, not a real pattern.
+
+**Pruning.** Two strategies:
+- *Pre-pruning*: stop growing early via `max_depth`, `min_samples_leaf`, `min_samples_split`. This is what you use in practice.
+- *Post-pruning*: grow a full tree, then remove branches that do not improve validation performance (cost-complexity pruning). Scikit-learn supports this via `ccp_alpha`.
+
+**Practical implications.** A single decision tree is rarely used alone in production. It is high-variance (small data changes produce very different trees) and low-bias only when deep. But understanding trees is essential because every ensemble method (bagging, random forests, gradient boosting) builds on them.
+
+**Common failure modes.**
+- Deep trees overfit aggressively on noisy sensor data. A 1000-tag historian dataset will produce a tree that memorises batch-specific artefacts.
+- Trees cannot extrapolate. If training data has inlet temperatures between 350 to 400 °C, the tree's prediction for 420 °C is just the prediction of whichever leaf 400 °C falls into. There is no linear extension. This matters enormously for plant data where operators occasionally push beyond historical ranges.
+- Axis-aligned splits only. A tree can only split on one feature at a time, so a diagonal decision boundary in feature space requires many splits to approximate. Neural networks handle this naturally.
+
+### Bagging and random forests
+
+**Bagging** (bootstrap aggregating) reduces variance by training multiple trees on different bootstrap samples (random draws with replacement from the training set), then averaging their predictions. Each tree overfits differently; the average cancels out the noise.
+
+**Key intuition.** Think of it like ensembling in deep learning: if you trained 100 ResNets with different random seeds and averaged their outputs, you would get lower variance predictions even though each individual model might overfit. Bagging does the same thing, but instead of different initialisations, it uses different data subsets.
+
+**Random forests** add a second source of randomness: at each split, the algorithm only considers a random subset of features (typically $\sqrt{p}$ for classification, $p/3$ for regression, where $p$ is the total number of features). This decorrelates the trees. Without this, if one feature is very strong (say, reactor temperature dominates yield prediction), every tree splits on it first and all trees look similar, defeating the purpose of averaging.
+
+**Practical implications.**
+- Random forests are embarrassingly parallel. Each tree is independent, so `n_jobs=-1` scales training linearly with cores. This matters with 1000+ tags and multi-year data.
+- Out-of-bag (OOB) error: each tree never sees ~37% of the training data (the samples not drawn in its bootstrap). You can evaluate on those unseen samples to get a free validation estimate without a separate holdout set. Useful for quick iteration, but do not use it as the final evaluation, use a proper chronological split for time-series data.
+- Random forests are hard to catastrophically break. With reasonable defaults (`n_estimators=500`, no depth limit or a generous one, `min_samples_leaf=5`), they perform well without tuning. This makes them an excellent baseline before moving to boosting.
+
+**Common failure modes.**
+- Random forests do not extrapolate either. The prediction is an average of leaf values, all of which are bounded by the training target range. If the plant operates at a new setpoint producing yields outside the historical range, the RF will clip its prediction.
+- Slow at inference time with many trees. Each sample must traverse every tree. For real-time soft sensors (sub-second prediction), 5000-tree forests can be too slow. Boosted models typically need fewer trees for the same accuracy.
+- Poor on very high-cardinality sparse features, not common in historian data but worth knowing.
+
+### Bias and variance
+
+Every model's prediction error on unseen data decomposes into three parts: $\text{bias}^2 + \text{variance} + \text{irreducible noise}$.
+
+- **Bias** is the error from wrong assumptions. A linear model fitting a nonlinear yield curve has high bias. A shallow tree also has high bias, it cannot represent the complexity.
+- **Variance** is the error from sensitivity to training data. A deep tree trained on 30s historian data will produce wildly different splits on different time windows: high variance.
+- **Irreducible noise** is the fundamental measurement noise in sensors and lab readings. No model can reduce this.
+
+**Key intuition.** In deep learning, you manage this tradeoff with model capacity (architecture size), dropout, weight decay, and data augmentation. In tree-based methods, the knobs are: tree depth (capacity), number of trees (averaging reduces variance), and the learning rate in boosting (controls how much each tree contributes, trading speed for variance reduction).
+
+**Where each method sits:**
+- Single deep tree: low bias, high variance.
+- Single shallow tree (stump): high bias, low variance.
+- Random forest: low bias (deep trees), reduced variance (averaging).
+- Gradient boosting with small learning rate: low bias (many trees iteratively correct errors), low variance (each tree contributes little).
+
+**Practical implication.** For plant data, sensor noise is significant (instrument error, discretisation, lag). You cannot eliminate irreducible noise. The job is to reduce bias (use flexible enough models) and variance (use ensembles, regularisation) without fitting the noise. The diagnostic tool is the gap between training and validation error: a large gap means high variance (overfitting); both being high means high bias (underfitting).
+
+### Feature importance
+
+Tree models offer multiple ways to rank features by importance. Understanding the differences matters because these are what you use to communicate with process engineers.
+
+**Impurity-based importance** (the default in scikit-learn). For each feature, sum the total reduction in impurity (e.g., variance) across all splits that use that feature, across all trees. Fast to compute, but biased toward high-cardinality features and features with many possible split points. A sensor tag sampled at 30s with high resolution will appear more important than a daily lab reading simply because the tree has more candidate thresholds to choose from.
+
+**Permutation importance.** After training, randomly shuffle one feature's values in the validation set and measure how much the model's performance degrades. A feature is important if shuffling it hurts predictions. This is model-agnostic and avoids the cardinality bias. Use this for reliable importance rankings.
+
+**SHAP values** (SHapley Additive exPlanations). Assigns each feature a contribution to each individual prediction, grounded in cooperative game theory. The sum of SHAP values for a sample plus the base value equals the model's prediction for that sample. This gives both global importance (mean $|\text{SHAP}|$) and local explanations ("for this specific batch, high reactor pressure contributed +1.2% to predicted yield").
+
+**Practical implications.**
+- For explaining models to process engineers, SHAP beeswarm plots are the most effective tool. They show not just which features matter, but in which direction and at what values.
+- Never use impurity-based importance alone for feature selection. It will mislead you on mixed-cadence data (30s historian vs. daily lab readings).
+- Permutation importance should be computed on the validation set, not the training set. On the training set, a model may have memorised the relationship, making the importance unreliable.
+
+**Common failure modes.**
+- Correlated features split importance among themselves. If three pressure tags are highly correlated, each may appear moderately important while a single uncorrelated flow tag appears more important. SHAP handles this better than permutation importance, but not perfectly. Group correlated features before interpreting.
+- Computing SHAP on 1000+ features with 100k+ samples is slow. Use `shap.TreeExplainer` (exact and fast for tree models), not `KernelExplainer`.
+
+### Regularisation controls
+
+Overfitting in tree models looks different from deep learning. There is no weight decay in the traditional sense, but there are equivalent controls.
+
+**Tree-level regularisation:**
+- `max_depth`: limits how many sequential splits a tree can make. Analogous to limiting network depth.
+- `min_samples_leaf` / `min_child_weight` (XGBoost): requires a minimum number of samples in each leaf. Analogous to requiring a minimum batch size for a gradient update, it prevents the model from making decisions based on too few data points.
+- `max_features` / `colsample_bytree`: limits how many features are considered at each split. Analogous to dropout, it forces the model not to rely on any single feature.
+
+**Ensemble-level regularisation:**
+- `n_estimators` + early stopping: more trees reduce training error but eventually overfit. Stop when validation error plateaus.
+- `learning_rate` (boosting only): shrinks each tree's contribution. Smaller values need more trees but generalise better. Analogous to learning rate in SGD.
+- `subsample` / `bagging_fraction`: train each tree on a random fraction of the data. Injects noise similar to mini-batch SGD.
+
+**Practical implications.**
+- The most important regularisation control in boosting is the learning rate + early stopping combination. Set the learning rate small (0.01 to 0.1), set `n_estimators` high (1000 to 10000), and let early stopping decide when to stop. This is the tree-model equivalent of training a neural network with a learning rate schedule and patience-based stopping.
+- For plant data with 1000+ tags, `colsample_bytree` between 0.3 and 0.7 is important. Without it, the model will overuse a few dominant tags and miss secondary patterns.
+
+**Common failure mode.** Tuning `max_depth` without also tuning `min_child_weight` or `min_samples_leaf`. A depth-6 tree sounds conservative, but if there is no minimum leaf size, some leaves will contain 1 or 2 samples from unusual operating conditions, and predictions for those regions will be unreliable.
+
+## How boosting works
+
+### Iterative error correction
+
+Bagging builds many independent models and averages them. Boosting builds models *sequentially*, where each new model focuses on the errors of the ensemble so far.
+
+**Key intuition.** Imagine a simple model predicting furnace outlet temperature. It gets most operating conditions right but consistently underpredicts during startup periods. A boosting approach trains the next model specifically on those residual errors, the gap between prediction and actual. The second model learns "when in startup mode, add +15 °C to the prediction." The ensemble prediction is the sum of all models.
+
+**The deep learning analogy.** This is like functional gradient descent. In neural networks, you compute the gradient of the loss with respect to *parameters* and update the weights. In boosting, you compute the gradient of the loss with respect to the *predictions* and fit a new tree to approximate that gradient. Each tree is a step in function space.
+
+**Residual fitting (simplified view for squared error loss):**
+1. Initialise predictions: $F_0(x) = \operatorname{mean}(y)$, the best constant prediction.
+2. Compute residuals: $r_i = y_i - F_0(x_i)$ for each sample.
+3. Fit a small tree to the residuals. Call it $h_1(x)$.
+4. Update: $F_1(x) = F_0(x) + \eta \, h_1(x)$, where $\eta$ is the learning rate.
+5. Compute new residuals: $r_i = y_i - F_1(x_i)$.
+6. Repeat.
+
+After $M$ rounds: $F_M(x) = F_0(x) + \eta \sum_{m=1}^{M} h_m(x)$.
+
+![Gradient boosting residual fitting — three rounds of iterative correction on reactor yield prediction](images/gradient_boosting_residual_fitting.svg)
+
+**Why this works.** Each tree only needs to explain what the current ensemble gets wrong. Early trees capture the big patterns (temperature drives yield). Later trees capture subtler effects (catalyst age interaction with feed composition). This additive structure means boosting can fit complex functions with simple base learners (shallow trees, typically depth 3 to 6).
+
+**Practical implication.** Because trees are added sequentially, boosting is inherently sequential: you cannot parallelise across trees the way you can with a random forest. You can parallelise *within* each tree (evaluating split candidates), but not across trees. This makes boosting slower to train than random forests on the same hardware.
+
+### Gradient boosting mechanics
+
+The generalisation from residual fitting to *gradient* boosting is what makes the framework powerful: it works with any differentiable loss function.
+
+**The general algorithm:**
+1. Choose a loss function $L(y, F(x))$: squared error, absolute error, Huber, quantile, log-loss, etc.
+2. Initialise $F_0(x)$ to minimise the total loss (for squared error, this is the mean; for absolute error, the median).
+3. For $m = 1, 2, \ldots, M$:
+   - Compute the negative gradient of the loss with respect to the current prediction for each sample: $g_i = -\frac{\partial L(y_i, F_{m-1}(x_i))}{\partial F_{m-1}(x_i)}$. These are the "pseudo-residuals."
+   - Fit a regression tree $h_m(x)$ to these pseudo-residuals.
+   - Update: $F_m(x) = F_{m-1}(x) + \eta \, h_m(x)$.
+
+For squared error loss, the negative gradient is simply $(y_i - F(x_i))$, which is the residual, so "residual fitting" is a special case.
+
+**Why the loss function matters for plant data.** Squared error penalises large errors heavily. If furnace data has occasional temperature excursions (outliers from sensor glitches or upsets), the model will waste capacity fitting those outliers. Huber loss or MAE is more robust. Quantile loss lets you predict the 90th percentile of yield, useful for setting conservative production targets.
+
+**The four key hyperparameters:**
+- **Learning rate ($\eta$):** 0.01 to 0.3 typically. Smaller means more trees needed but better generalisation. This is the single most important hyperparameter.
+- **Number of estimators ($M$):** Controlled by early stopping. Set high and let validation loss determine the cutoff.
+- **Tree depth:** 3 to 8 for most problems. Deeper trees capture higher-order interactions but overfit faster. Depth 6 means the tree can represent up to 6-way feature interactions.
+- **Subsampling (`subsample`):** Training each tree on a random 50 to 80% of the data adds stochastic regularisation. Called "stochastic gradient boosting."
+
+**Practical implication.** The learning rate and number of trees are coupled. Halving the learning rate roughly doubles the number of trees needed to reach the same training loss, but often improves test performance. The standard practice is: set learning rate to 0.05 or 0.1, set `n_estimators` to 5000 to 10000, use early stopping with patience of 50 to 100 rounds.
+
+**Common failure mode.** Setting a high learning rate (0.3) with many trees. The model overshoots early, oscillates, and overfits. If validation loss decreases then increases sharply, the learning rate is too high.
+
+### Early stopping
+
+Early stopping in gradient boosting works the same way as in neural network training: monitor validation loss after each round (tree) and stop when it has not improved for a set number of rounds (patience).
+
+**Key intuition.** Each tree added reduces training loss monotonically (or nearly so). Validation loss decreases initially, flattens, then increases as the model overfits. The optimal number of trees is where validation loss is minimised. Early stopping finds this automatically.
+
+**Implementation:**
+- Pass an evaluation set (must be chronologically after training data for time series).
+- Set `early_stopping_rounds` (XGBoost) or `callbacks=[lgb.early_stopping(stopping_rounds=50)]` (LightGBM).
+- The model stores the best iteration and uses it for prediction.
+
+**Practical implications.**
+- Early stopping replaces manual tuning of `n_estimators`. Set it high and let the algorithm decide.
+- The patience parameter matters. With noisy plant data, validation loss can fluctuate. A patience of 50 rounds with a 0.05 learning rate means the model continues for 50 more trees after the best score, tolerating local fluctuations. Too small a patience stops prematurely.
+- Always use the model from the best iteration, not the final iteration. Both XGBoost and LightGBM support this via `best_iteration`.
+
+### Boosting vs bagging
+
+![Bagging vs boosting — parallel independent trees with averaging vs sequential corrective trees with weighted sum](images/bagging_vs_boosting.svg)
+
+| Dimension | Random Forest | Gradient Boosting |
+|-----------|---------------|-------------------|
+| Construction | Parallel, independent trees | Sequential, corrective trees |
+| Tree depth | Typically deep (unlimited) | Typically shallow (3 to 8) |
+| Bias-variance | Reduces variance via averaging | Reduces bias via iterative correction |
+| Overfitting risk | Hard to overfit with more trees | Easy to overfit with too many trees |
+| Tuning burden | Low, works well with defaults | Moderate: learning rate, depth, regularisation |
+| Training speed | Parallelisable across trees | Sequential across trees (parallel within tree) |
+| Inference speed | Slow with many trees | Faster (fewer, shallower trees) |
+| Extrapolation | Cannot | Cannot |
+
+**When to use which in plant applications:**
+- **Random forest** for a quick baseline, for feature importance screening on a new dataset, or when there is limited time to tune. Also prefer RF when the dataset is small and you cannot afford to overfit.
+- **Gradient boosting** when you need maximum predictive accuracy for a production model, when there is enough data for a proper validation set, and when you can invest time in tuning.
+
+**Practical implication.** Always train a random forest first. It gives a reliable baseline, fast feature importance, and a sense of what accuracy is achievable. Then switch to XGBoost or LightGBM and aim to beat the RF. If you cannot beat it, something is wrong with the boosting setup (leakage, bad hyperparameters, or the data simply does not benefit from sequential correction).
+
+## XGBoost
+
+### The regularised objective
+
+XGBoost's key innovation over vanilla gradient boosting is an explicit regularised objective function that is optimised directly.
+
+At each step $m$, XGBoost minimises:
+
+$$
+\mathrm{Obj} = \sum_i L\bigl(y_i,\, F_{m-1}(x_i) + h_m(x_i)\bigr) + \Omega(h_m)
+$$
+
+where $\Omega$ is a regularisation term on the new tree:
+
+$$
+\Omega(h) = \gamma T + \tfrac{1}{2}\lambda \sum_j w_j^2
+$$
+
+- $T$ is the number of leaves in the tree.
+- $w_j$ is the prediction value (weight) of leaf $j$.
+- $\gamma$ penalises tree complexity (more leaves = higher penalty). Analogous to an L0 penalty on the number of active neurons.
+- $\lambda$ penalises large leaf weights. Analogous to L2 weight decay in neural networks.
+
+**Key intuition.** Vanilla gradient boosting just fits trees to pseudo-residuals and hopes regularisation comes from small learning rates and early stopping. XGBoost bakes regularisation into the split decision itself. A split is only made if the gain exceeds $\gamma$. A leaf's weight is shrunk toward zero by $\lambda$. This means XGBoost's trees are structurally different from scikit-learn's gradient boosting trees.
+
+**Practical implication.** The $\gamma$ parameter (`min_split_loss` in XGBoost, `gamma` in the API) acts as a pruning threshold. Increasing $\gamma$ makes the model require larger improvements to justify a split, producing simpler trees. For noisy sensor data, a non-zero $\gamma$ (e.g., 0.1 to 1.0) prevents the model from making splits that explain tiny amounts of variance, splits that are likely fitting noise.
+
+### Second-order gradients (Newton's method)
+
+This is the mathematical core of what makes XGBoost faster to converge than vanilla gradient boosting.
+
+Vanilla gradient boosting uses only the first derivative (gradient) of the loss function. XGBoost uses both the first derivative ($g_i$) and the second derivative (Hessian, $h_i$):
+
+$$
+g_i = \frac{\partial L(y_i, \hat{y}_i)}{\partial \hat{y}_i} \qquad \text{(gradient)}
+$$
+
+$$
+h_i = \frac{\partial^2 L(y_i, \hat{y}_i)}{\partial \hat{y}_i^2} \qquad \text{(Hessian)}
+$$
+
+The optimal weight for leaf $j$ is:
+
+$$
+w_j^\star = -\frac{\sum_{i \in \text{leaf } j} g_i}{\sum_{i \in \text{leaf } j} h_i + \lambda}
+$$
+
+**Key intuition.** The deep learning analogy is exact: this is Newton's method vs standard gradient descent. First-order methods (SGD) use only the gradient to choose the direction. Second-order methods (Newton's method) use the curvature (Hessian) to choose both direction and step size. The Hessian tells you how "confident" the gradient signal is. If the loss surface is flat (small Hessian), the model should take a cautious step. If it's steep (large Hessian), the gradient signal is reliable.
+
+For squared error loss: $g_i = \hat{y}_i - y_i$, $h_i = 1$ (constant). So for MSE, the second-order information does not add much. The benefit appears with other loss functions (log-loss, quantile loss) where the curvature varies across the prediction space.
+
+**Practical implication.** This is why XGBoost converges in fewer boosting rounds than vanilla gradient boosting for the same accuracy: each tree makes a better-calibrated step. There is nothing to tune here, it happens automatically. But it explains why XGBoost is faster to train than a naive implementation.
+
+### Split gain
+
+When XGBoost evaluates whether to split a node, it computes the *gain* of the split:
+
+$$
+\text{Gain} = \tfrac{1}{2}\left[
+\frac{(\sum g_L)^2}{\sum h_L + \lambda}
++ \frac{(\sum g_R)^2}{\sum h_R + \lambda}
+- \frac{(\sum g_P)^2}{\sum h_P + \lambda}
+\right] - \gamma
+$$
+
+Where $L$ = left child, $R$ = right child, $P$ = parent (before split). The subscript sums are over the gradient and Hessian values of samples in each node.
+
+**Key intuition.** This formula directly answers: "Is this split worth it?" The first three terms measure how much better two children explain the gradients than the parent alone. The $\gamma$ term is the cost of adding a split. If $\text{Gain} \le 0$, the split is not made, the node remains a leaf. This is built-in pre-pruning, not an afterthought.
+
+**Why this matters for plant data.** With 1000+ features, the algorithm evaluates thousands of candidate splits per node. Many will have tiny positive gains: they explain a fraction of the residual variance that is likely noise. The $\gamma$ penalty filters these out at split time, producing cleaner trees than scikit-learn's gradient boosting (which does not have this mechanism by default).
+
+**Practical implication.** When tuning XGBoost, $\gamma$ and $\lambda$ together control model complexity. Start with $\gamma = 0$, $\lambda = 1$ (defaults). If the model overfits, increase $\gamma$ to 0.1 to 5.0 and $\lambda$ to 1 to 10. For regression on noisy data, these two parameters are often more effective than reducing tree depth.
+
+### Built-in missing value handling
+
+XGBoost natively handles missing values during both training and inference without imputation.
+
+**How it works.** At each split, the algorithm tries sending all samples with a missing value for that feature to the left child, then to the right child, and picks whichever direction gives a higher gain. This "default direction" is stored with the split. At inference time, if a value is missing, the sample follows the learned default direction.
+
+**Key intuition.** This is better than imputation for plant data because missingness is often informative. A sensor that goes offline may indicate a shutdown, a calibration event, or a fault. Imputing with the mean destroys that signal. XGBoost's approach lets the model learn that "missing Tag_A values tend to correlate with lower yield" without explicitly encoding this.
+
+**Practical implications.**
+- You can (and should) feed raw data with NaNs to XGBoost. Do not impute unless there is a domain reason.
+- LightGBM handles missing values the same way. Scikit-learn's `GradientBoostingRegressor` does not, it requires imputation or will raise an error.
+- If a sensor has a "bad value" placeholder (e.g., $-9999$ or 0 when the true range is 50 to 200), replace those with NaN before training so that XGBoost's missing value logic handles them correctly. Otherwise the model will learn splits on $-9999$ as if it were a real reading.
+
+**Common failure mode.** Blindly imputing with mean/median before feeding data to XGBoost. You lose the informative missingness signal and may introduce bias (e.g., imputing a temperature with the global mean when the sensor was down during a shutdown, where the true temperature was likely ambient, not the mean operating temperature).
+
+### Hyperparameters and tuning order
+
+Rather than tuning all parameters simultaneously, use a staged approach.
+
+**Tier 1, set first, most impact:**
+- `learning_rate` ($\eta$ / `eta`): Start with 0.05. Range: 0.01 to 0.3.
+- `n_estimators`: Set to 5000 to 10000. Let early stopping decide.
+- `max_depth`: Start with 6. Range: 3 to 10. Controls the maximum interaction order.
+- `early_stopping_rounds`: 50 to 100.
+
+**Tier 2, tune second, regularisation:**
+- `min_child_weight`: Minimum sum of instance weight (hessian) in a leaf. Start with 1. Increase to 5 to 100 for noisy data. For MSE loss, this equals the minimum number of samples in a leaf.
+- `subsample`: Fraction of training data per tree. Start with 0.8. Range: 0.5 to 1.0.
+- `colsample_bytree`: Fraction of features per tree. Start with 0.8. Range: 0.3 to 1.0.
+- `gamma`: Minimum split gain. Start with 0. Increase if overfitting.
+- `reg_lambda` ($\lambda$): L2 regularisation. Start with 1. Range: 0 to 10.
+- `reg_alpha` ($\alpha$): L1 regularisation on leaf weights. Useful for sparse feature spaces. Start with 0.
+
+**Tier 3, rarely changed:**
+- `max_leaves`: Alternative to `max_depth` for controlling tree size.
+- `colsample_bylevel`, `colsample_bynode`: Finer-grained feature sampling.
+- `scale_pos_weight`: For imbalanced classification only.
+
+**Tuning workflow:**
+1. Fix `learning_rate = 0.05`, `max_depth = 6`, defaults for everything else. Train with early stopping. Note the best number of rounds and validation score.
+2. Do a coarse grid or Bayesian search over `max_depth` (3 to 8), `min_child_weight` (1, 5, 10, 50), `subsample` (0.6, 0.8, 1.0), `colsample_bytree` (0.5, 0.7, 1.0).
+3. Fine-tune `gamma` and `reg_lambda` if still overfitting.
+4. Optionally reduce `learning_rate` to 0.01 and retrain with more rounds for the final model.
+
+**Common failure modes.**
+- Tuning `n_estimators` directly instead of using early stopping. Never manually fix the number of trees.
+- Overfitting `max_depth` because it is the most visible knob. Depth 10+ rarely helps and usually hurts unless the data is very large and there are many meaningful interactions.
+- Neglecting `colsample_bytree` on wide datasets. With 1000+ tags, forcing the model to work with a random subset at each tree is critical for generalisation.
+
+### Failure modes on process data
+
+1. **Overfitting to sensor noise.** 30-second historian data is noisy. A model trained on raw data with depth 10 and no regularisation will memorise transients. Downsample or aggregate to a meaningful cadence (1 min, 5 min) and use regularisation.
+
+2. **Data leakage from future features.** If the feature matrix includes values that would not be available at prediction time (e.g., a lab reading that arrives 4 hours after the event being predicted), the model will appear excellent in training but fail in production. Boosted trees exploit leakage aggressively because they are powerful enough to pick up on even subtle future information.
+
+3. **Target leakage from correlated tags.** If predicting yield at the plant outlet and one of the features is a downstream flow measurement that is itself derived from yield, that is leakage. The model will learn to use that feature, and SHAP will show it as the top feature, a red flag.
+
+4. **Training on shutdown/startup data.** Plant data during shutdowns and startups is fundamentally different from steady-state operation. Mixing them in training makes the model learn an average that is good at neither. Filter or segment by operating regime.
+
+5. **Ignoring the no-extrapolation limitation.** If the model was trained on data from 2019 to 2023 and the plant then installs a new catalyst with higher activity, all features related to that catalyst behave differently. The model cannot extrapolate and will produce unreliable predictions until retrained.
+
+## LightGBM
+
+### Histogram-based splitting
+
+In standard (exact) gradient boosting, the algorithm evaluates every unique value of every feature as a candidate split point. With millions of rows and thousands of features, this is expensive.
+
+LightGBM bins continuous features into a fixed number of discrete bins (default 255) before training. Instead of evaluating every unique value, it evaluates only the bin boundaries.
+
+**Key intuition.** Think of it as quantisation. Instead of working with raw 32-bit floating point values, you work with 8-bit buckets. You lose some precision on where exactly to split, but you gain enormous speed: the histogram for each feature can be built in a single pass through the data, and subtraction (parent histogram minus left child histogram = right child histogram) halves the work further.
+
+**Practical implications.**
+- Training is 5 to 20x faster than exact methods on large datasets. For a multi-year historian dataset with millions of rows, this is the difference between a 2-hour training run and a 10-minute one.
+- The accuracy loss from binning is negligible in practice. With 255 bins, the approximation error is smaller than the noise in most sensor data.
+- XGBoost also supports histogram-based splitting (`tree_method='hist'`), but LightGBM was designed around it from the ground up and is generally faster.
+- The `max_bin` parameter controls the number of bins. Default 255 is almost always sufficient. Increasing it increases precision but slows training.
+
+### Leaf-wise vs level-wise growth
+
+This is the most important architectural difference between LightGBM and XGBoost.
+
+**Level-wise (XGBoost default):** The tree grows one full level at a time. All nodes at depth $d$ are split before moving to depth $d+1$. This produces balanced trees. Every leaf is at the same depth.
+
+**Leaf-wise (LightGBM default):** The algorithm picks the leaf with the highest gain across the entire tree and splits that one leaf, regardless of depth. This produces unbalanced trees. Some branches go deep where the data has complex patterns; other branches stay shallow where the data is simple.
+
+![Level-wise vs leaf-wise tree growth — balanced tree from level-wise vs unbalanced tree from leaf-wise where capacity focuses on highest-gain regions](images/levelwise_vs_leafwise_growth.svg)
+
+**Key intuition.** Level-wise growth is like training all layers of a neural network with the same width. Leaf-wise growth is like allocating more capacity where the loss is highest, focusing the model's complexity budget where it matters most. For plant data, this means the tree might go 15 levels deep on a specific operating regime where yield behaviour is complex, while staying 3 levels deep on normal steady-state operation.
+
+**Practical implications.**
+- Leaf-wise growth achieves lower loss with fewer leaves. LightGBM often needs fewer boosting rounds to reach the same accuracy as XGBoost.
+- Leaf-wise growth overfits faster. Because it aggressively pursues the highest-gain splits, it can fit noise more quickly. This is the core tradeoff.
+- In LightGBM, tree size is controlled primarily via `num_leaves` (max number of leaves), not `max_depth`. The default `num_leaves = 31` corresponds roughly to a balanced tree of depth 5 ($2^5 = 32$ leaves). But since the tree is unbalanced, some paths may be much deeper than 5.
+- `max_depth` in LightGBM is a secondary constraint (default $-1$ = no limit). Set it to prevent pathologically deep branches, e.g., `max_depth = 10`.
+
+### `num_leaves` and `min_data_in_leaf`
+
+These are the two most important hyperparameters in LightGBM and the primary tools for controlling overfitting.
+
+**`num_leaves`** (default 31): Maximum number of leaves per tree. This is the main capacity control. Unlike `max_depth` in XGBoost (which limits depth uniformly), `num_leaves` limits total tree complexity while allowing variable depth.
+
+- Too high → overfitting (the tree is too complex).
+- Too low → underfitting (the tree cannot capture interactions).
+- Rule of thumb: `num_leaves` should be less than $2^{\text{max\_depth}}$ if you also set `max_depth`. For most problems, 15 to 127.
+
+**`min_data_in_leaf`** (default 20): Minimum number of samples required in each leaf. This is LightGBM's equivalent of `min_child_weight` in XGBoost (when using MSE loss).
+
+- Too low → leaves with few samples, predictions based on noise.
+- Too high → cannot capture minority patterns (e.g., a specific rare operating regime).
+- For large datasets (100k+ rows), values of 50 to 500 work well. For small datasets (1k to 10k), use 5 to 20.
+
+**Key intuition.** `num_leaves` controls the tree's maximum expressiveness. `min_data_in_leaf` controls the minimum statistical support for any prediction. You need both. A tree with `num_leaves=127` but `min_data_in_leaf=100` is powerful yet stable. A tree with `num_leaves=127` and `min_data_in_leaf=1` is a recipe for overfitting.
+
+**Practical implication.** When moving from XGBoost to LightGBM, do not just translate `max_depth` to `num_leaves = 2^{\text{max\_depth}}`. Start with `num_leaves=31`, `min_data_in_leaf=20`, and adjust from there. The tuning dynamics are different.
+
+### GOSS and EFB
+
+These are two algorithmic optimisations that give LightGBM additional speed on large datasets. Understanding them conceptually is sufficient.
+
+**GOSS (Gradient-based One-Side Sampling).** Instead of using all training samples to compute the histogram at each split, GOSS keeps all samples with large gradients (high residuals, the "hard" examples) and randomly samples from the rest. The rationale: samples with small gradients are already well-predicted, so they contribute less to the split decision.
+
+- Deep learning analogy: this is like hard example mining or focal loss, spending more compute on the samples the model gets wrong.
+- In practice, controlled by `top_rate` (fraction of large-gradient samples to keep, default 0.2) and `other_rate` (sampling rate for the rest, default 0.1). These defaults are aggressive. Using `boosting_type='goss'` enables it.
+- Downside: GOSS introduces noise in gradient estimates, which can hurt when all samples carry useful signal (e.g., stable steady-state operation where residuals are small but meaningful).
+
+**EFB (Exclusive Feature Bundling).** When features are mutually exclusive (rarely nonzero at the same time), EFB bundles them into a single feature. This reduces the effective number of features the algorithm must process.
+
+- Useful for one-hot encoded categoricals or sparse features. Less relevant for dense historian data where all tags are continuously valued.
+- Happens automatically; there is nothing to configure.
+
+**Practical implication.** On dense historian data with 1000+ continuous tags, EFB will have minimal effect. GOSS can speed up training but may not improve accuracy. The default `boosting_type='gbdt'` (standard gradient boosting) is usually the best choice. Switch to GOSS only if training time is a bottleneck and accuracy has been verified as not degraded on the validation set.
+
+### Categorical features
+
+LightGBM can handle categorical features natively, without one-hot encoding.
+
+**How it works.** For each categorical feature at each split, LightGBM finds the optimal partition of categories into two groups. It does this efficiently by sorting categories by their gradient statistics (within each category: $\sum_i g_i \big/ \sum_i h_i$) and then evaluating splits along this sorted order, reducing the problem from exponential (all possible subsets) to linear (all contiguous subsets along the sorted order).
+
+**Why this matters for plant data.** Typical categorical features include operating mode (normal / startup / shutdown / turndown), catalyst batch ID, shift (day / night), feed source (crude A / crude B). One-hot encoding creates sparse features that trees split on inefficiently. Native categorical handling lets the tree find "catalyst batches {B, D, F} behave differently from {A, C, E}" in a single split rather than requiring multiple splits.
+
+**Practical implications.**
+- Declare categoricals explicitly: `lgb.Dataset(X, y, categorical_feature=['op_mode', 'catalyst_id'])`.
+- Do not one-hot encode features meant for LightGBM's native handling. It defeats the purpose.
+- XGBoost added experimental categorical support in version 1.6, but it is less mature than LightGBM's. If categoricals are important, prefer LightGBM.
+- High-cardinality categoricals (e.g., individual batch IDs with hundreds of unique values) can still overfit. Use `min_data_per_group` (default 100) and `cat_smooth` (default 10) to regularise.
+
+### Why LightGBM overfits quickly, and how to control it
+
+LightGBM's leaf-wise growth strategy is more aggressive than XGBoost's level-wise growth. Combined with histogram approximation (which speeds up training enough to allow many more rounds), LightGBM can overfit before you notice.
+
+**Signs of overfitting:**
+- Training RMSE continues to drop while validation RMSE plateaus or increases.
+- SHAP importance shows many features with small but nonzero importance: the model is using everything, including noise.
+- The model performs well on steady-state data but poorly on regime transitions.
+
+**Controls (in order of importance):**
+1. `num_leaves`: Reduce from 31 to 15 or 7.
+2. `min_data_in_leaf`: Increase from 20 to somewhere in 50 to 200.
+3. `learning_rate`: Reduce to 0.01 to 0.05 and let early stopping run longer.
+4. `feature_fraction` (= `colsample_bytree`): 0.5 to 0.8.
+5. `bagging_fraction` + `bagging_freq`: Subsample 60 to 80% of data every 1 to 5 rounds.
+6. `lambda_l1`, `lambda_l2`: L1/L2 regularisation on leaf weights. Start with 0, increase to 0.1 to 10.
+7. `min_gain_to_split` (same role as $\gamma$ in XGBoost): 0.01 to 1.0.
+8. `max_depth`: Set as a safety net, e.g., 8 to 12, even though `num_leaves` is the primary control.
+
+**Practical implication.** The biggest mistake when switching from XGBoost to LightGBM is underestimating how much regularisation is needed. LightGBM's defaults are tuned for speed and low training error, not for generalisation on noisy data. For industrial historian data, start conservative: `num_leaves=15`, `min_data_in_leaf=100`, `learning_rate=0.05`, and open up capacity only if the model underfits.
+
+## XGBoost vs LightGBM in practice
+
+| Dimension | XGBoost | LightGBM |
+|-----------|---------|----------|
+| Tree growth | Level-wise (default) | Leaf-wise (default) |
+| Complexity control | `max_depth` | `num_leaves` + `min_data_in_leaf` |
+| Speed | Fast (with `tree_method='hist'`) | Faster (native histogram design) |
+| Categoricals | Experimental support | Mature native support |
+| Missing values | Native handling | Native handling |
+| Default overfitting risk | Moderate | Higher (needs more regularisation) |
+| API style | `xgb.train()` with DMatrix | `lgb.train()` with Dataset |
+| GPU support | Good | Good |
+| Community/production | Extremely mature, widely deployed | Mature, widely deployed, growing |
+
+**When to prefer XGBoost:** When you want a more conservative default, when the team is already using XGBoost in production, when categorical features are not important.
+
+**When to prefer LightGBM:** When training speed matters (large datasets), when there are important categorical features, when more aggressive regularisation tuning is acceptable.
+
+**Practical implication.** On industrial process data, try both. Train an XGBoost model and a LightGBM model with equivalent tuning effort. Pick whichever generalises better on walk-forward validation. The difference in final accuracy is often $<1\%$, and the choice often comes down to team familiarity and training speed.
+
+## Time series with boosted trees
+
+### Framing a forecast as supervised learning
+
+Boosted trees do not natively understand time. They see a matrix of rows (samples) and columns (features), with no notion of sequence. To use them for time-series forecasting, the problem must be converted into a tabular supervised learning format.
+
+**The core transformation:** For each timestamp $t$ at which you want to make a prediction, construct a feature row using only information available at or before $t$, and assign the target $y(t)$ or $y(t+h)$, where $h$ is the forecast horizon.
+
+**Feature categories:**
+
+*Lag features.* The value of a variable at previous time steps. If predicting yield at time $t$, features might include $y(t-1)$, $y(t-2)$, $y(t-24\,\mathrm{h})$. These give the model access to recent history.
+
+*Rolling/window features.* Summary statistics over a trailing window: mean, std, min, max over the last 1 hour, 4 hours, 24 hours. These capture trends and volatility. For a reactor temperature tag, `temp_rolling_mean_1h` smooths out noise, while `temp_rolling_std_1h` captures instability.
+
+*Expanding features.* Statistics computed from the start of a run or campaign up to time $t$. For example, cumulative catalyst hours, cumulative feed processed. These capture long-term degradation effects.
+
+*Calendar/cyclical features.* Hour of day, day of week, month. In a plant, these capture shift changes, weekend effects, seasonal ambient temperature differences. Encode cyclical features with sin/cos transforms or as categoricals.
+
+*Known future covariates.* Variables whose future values are known at prediction time: scheduled setpoints, planned production targets, weather forecasts, planned maintenance windows. These are features, not targets, and their future values are usable because they are deterministic or forecasted independently.
+
+![Time series to supervised learning — feature row construction showing lag, rolling, calendar features and a leakage example](images/timeseries_to_supervised_learning.svg)
+
+**Key intuition.** This is analogous to preparing data for a causal (autoregressive) language model: the model only sees tokens to the left of the current position. Here, the model only sees data at or before time $t$. Any feature that uses data from after $t$ is leakage.
+
+**Common failure mode.** Using pandas `rolling()` without setting `closed='left'` or shifting properly. The default rolling window in pandas includes the current row, which is correct for features like `temperature_rolling_mean_1h` (the mean temperature over the past hour up to now). But if the target is the value at time $t$ and you compute `target_rolling_mean_1h` including time $t$, the target has leaked into the features.
+
+### Forecast horizon and known future covariates
+
+The **forecast horizon** $h$ is how far ahead you are predicting. This choice fundamentally shapes feature engineering and model design.
+
+**Direct forecasting:** Train a separate model for each horizon. $\text{Model}_1$ predicts $y(t+1)$, $\text{Model}_6$ predicts $y(t+6)$. Each model's features use only data available at time $t$. Simple, but requires $N$ models for $N$ horizons.
+
+**Recursive forecasting:** Train one model to predict $y(t+1)$. For $y(t+2)$, use the model's own prediction of $y(t+1)$ as a feature. Errors compound: the prediction for $y(t+6)$ uses five layers of imperfect predictions. Generally not recommended for boosted trees because trees cannot extrapolate, so errors accumulate into unreliable regions.
+
+**Direct multi-output:** Train one model that predicts a vector $[y(t+1), y(t+2), \ldots, y(t+h)]$ simultaneously. XGBoost and LightGBM do not natively support this (they predict scalars), so this needs separate models or a wrapper. In practice, direct single-horizon models are the standard approach.
+
+**Known future covariates.** Some variables have known future values at prediction time:
+- Planned setpoints (the operator schedule for the next shift is published in advance).
+- Weather forecasts (ambient temperature for the next 24 hours).
+- Calendar features (we know what hour/day it will be).
+- Maintenance schedules.
+
+Include these as features, using their values at the *target* time, not the *prediction* time. For example, if predicting yield at $t + 6\,\mathrm{h}$ and the planned reactor temperature setpoint for $t + 6\,\mathrm{h}$ is known, include it as a feature. This is not leakage, it is information you genuinely have.
+
+**Key intuition.** The question to ask for every feature is: "At the moment I need to make this prediction, do I have this value?" If yes, it is a valid feature. If no, it is leakage (or it needs to be itself forecasted).
+
+### Chronological splits and walk-forward validation
+
+**Critical rule: never use random train/test splits for time-series data.**
+
+Random splits allow the model to see future data in training and evaluate on past data in testing. The model can exploit autocorrelation (the past looks like the nearby future) and any temporal leakage, giving wildly optimistic error estimates.
+
+**Chronological split:** Training data = all data before time $T_1$. Validation data = all data from $T_1$ to $T_2$. Test data = all data after $T_2$. The model never sees future data during training.
+
+**Walk-forward validation** (expanding window or sliding window):
+1. Train on data from $t_0$ to $T_1$. Validate on $T_1$ to $T_1+\Delta$.
+2. Train on data from $t_0$ to $T_1+\Delta$. Validate on $T_1+\Delta$ to $T_1+2\Delta$.
+3. Repeat.
+
+Each fold uses a strictly later period for validation. The final metric is the average across all folds.
+
+**Expanding window** keeps all historical data in the training set. **Sliding window** drops old data (e.g., always train on the most recent 6 months). Sliding windows are better when the process changes over time (catalyst degradation, equipment replacement) and old data may be misleading.
+
+![Walk-forward validation — expanding and sliding window folds vs the wrong random split approach](images/walkforward_validation.svg)
+
+**Practical implications.**
+- For plant data with regime changes, walk-forward with a sliding window is the most realistic evaluation. It answers: "How well does the model perform when retrained monthly on the last 6 months of data?"
+- The validation period should cover at least one full cycle of any periodicity in the data. If there are seasonal effects, each fold should include enough time to capture them. For 30s historian data, a validation window of 1 to 4 weeks is typical.
+- With only 1 year of data, a simple chronological 70/15/15 split is more practical than walk-forward (too few folds).
+
+**Common failure mode.** Using scikit-learn's `cross_val_score` with default KFold. This shuffles data and creates random splits. Use `TimeSeriesSplit` from scikit-learn, or implement walk-forward manually.
+
+### Leakage detection
+
+Leakage is the most dangerous failure mode in time-series ML for plant data. The model looks excellent in validation but fails in production. Types of leakage:
+
+**Direct target leakage.** A feature that is computed from or is a direct proxy for the target variable. Example: including the outlet product quality analyser reading as a feature when predicting product quality. This is obvious but becomes subtle with 1000+ tags where some downstream measurements are indirect functions of the target.
+
+**Temporal leakage.** A feature that uses information from after the prediction time. Examples:
+- A rolling average that includes future values (wrong window alignment).
+- A lab reading timestamped at 8 AM that actually reflects a sample taken at 6 AM and analysed by 8 AM, but the model uses it to predict 7 AM yield.
+- An event flag (shutdown = True) that is coded retrospectively. At the time of prediction, you might not yet know that a shutdown has begun.
+
+**Train/test leakage.** Information from the test set that leaks into training. Example: normalising features using the global mean/std (including test data) rather than using only training-set statistics.
+
+**Detection strategies:**
+1. **Suspiciously high accuracy.** If the model achieves $R^2 > 0.98$ on what should be a noisy industrial process, suspect leakage before celebrating.
+2. **Feature importance analysis.** If SHAP shows a single feature dominating with unreasonably high importance, investigate whether it is a proxy for the target or uses future information.
+3. **Ablation testing.** Remove the top feature and retrain. If performance drops dramatically, that feature may be leaking. If performance drops only modestly, the model has redundant information and is likely sound.
+4. **Production simulation.** Build the feature engineering pipeline exactly as it would run in production (only using data available at prediction time) and compare performance to the offline evaluation. A large gap means the offline pipeline had leakage.
+
+**Practical implication.** The single best defence against leakage is to implement a `make_features(timestamp)` function that takes a prediction time and returns a feature vector using only data available at that time. Use this same function for both training and inference. If the training pipeline and inference pipeline use different code paths, leakage is almost guaranteed.
+
+### Baselines
+
+Never evaluate a model in isolation. Always compare against baselines that establish what accuracy is "free" before any machine learning.
+
+**Naive baseline:** Predict $y(t+h) = y(t)$. The forecast is just the last known value. For slow-moving processes (yield changes over hours), this is surprisingly hard to beat at short horizons.
+
+**Seasonal naive:** Predict $y(t+h) = y(t - L + h)$ where $L$ is the seasonal period (e.g. 24 hours). If yield has a 24-hour cycle (day vs night shifts), the seasonal naive uses yesterday's value at the same hour. This captures periodic patterns with zero ML.
+
+**Linear baseline:** Train a simple linear regression on the same features. This establishes how much of the predictable signal is linear vs nonlinear. If the linear model achieves $R^2 = 0.85$ and the boosted model achieves $R^2 = 0.87$, the trees are adding marginal value and the added complexity is questionable.
+
+**Random forest baseline:** RF with defaults is a strong, low-effort baseline for nonlinear models. If XGBoost/LightGBM cannot beat it, something is misconfigured.
+
+**Practical implication.** Report all baselines alongside the model. For a refinery yield model, the table might be:
+
+| Model | Validation RMSE | vs Naive |
+|-------|----------------|----------|
+| Naive (last value) | 2.1 | — |
+| Seasonal naive (24h) | 1.8 | −14% |
+| Linear regression | 1.3 | −38% |
+| Random forest | 0.95 | −55% |
+| LightGBM (tuned) | 0.88 | −58% |
+
+This tells the story: most of the value comes from using any model; the gap between RF and LightGBM is small; the model is adding real signal beyond naive approaches.
+
+### Metrics that map to business value
+
+Standard ML metrics (RMSE, MAE, $R^2$) do not directly tell you whether the model is useful for plant operations. Choose metrics that connect to the decision being made.
+
+**RMSE (Root Mean Squared Error).** Penalises large errors heavily. Good when large mispredictions are operationally costly (e.g., predicting furnace temperature, where a $20^\circ\mathrm{C}$ error is much worse than $4\times$ a $5^\circ\mathrm{C}$ error).
+
+**MAE (Mean Absolute Error).** Treats all errors proportionally. Better when average performance is what matters and outlier errors are not catastrophically worse (e.g., daily production volume forecasting).
+
+**MAPE (Mean Absolute Percentage Error).** Interpretable to business stakeholders ("the model is off by 3% on average"). But fails when the target is near zero (division by zero/infinity) and biases toward underestimation. Use with caution.
+
+**Quantile loss.** If the business decision is about risk management (e.g., "what is the minimum yield we can guarantee with 90% confidence?"), use quantile regression to predict the 10th percentile. The quantile loss function directly optimises for this.
+
+**Direction accuracy.** For some applications, getting the direction right matters more than the magnitude. "Will yield go up or down in the next 4 hours?" can be evaluated separately from the magnitude of the prediction.
+
+**Domain-specific metrics.** Work with process engineers to define what matters:
+- Percentage of time the prediction is within ±1% of actual yield.
+- Number of false alarms (predicted upset that did not occur) vs missed alarms.
+- Economic value: if the model's prediction is used to adjust a setpoint, what is the dollar value of the improved yield?
+
+**Practical implication.** Always include at least one business-interpretable metric alongside RMSE. "RMSE = 0.88" means nothing to a plant manager. "The model predicts yield within ±1.5% for 90% of hours" is actionable.
+
+## Quick reference
+
+### XGBoost hyperparameters
+
+| Parameter | Default | Typical Range | Effect |
+|-----------|---------|---------------|--------|
+| `learning_rate` ($\eta$, `eta`) | 0.3 | 0.01-0.1 | Shrinks each tree's contribution |
+| `max_depth` | 6 | 3-10 | Max interaction order |
+| `min_child_weight` | 1 | 1-100 | Min samples (hessian) per leaf |
+| `subsample` | 1 | 0.5-0.9 | Row sampling per tree |
+| `colsample_bytree` | 1 | 0.3-0.8 | Feature sampling per tree |
+| `gamma` ($\gamma$) | 0 | 0-5 | Min split gain |
+| `reg_lambda` ($\lambda$) | 1 | 0-10 | L2 on leaf weights |
+| `reg_alpha` ($\alpha$) | 0 | 0-10 | L1 on leaf weights |
+
+### LightGBM hyperparameters
+
+| Parameter | Default | Typical Range | Effect |
+|-----------|---------|---------------|--------|
+| `learning_rate` ($\eta$) | 0.1 | 0.01-0.1 | Shrinks each tree's contribution |
+| `num_leaves` | 31 | 7-127 | Max leaves per tree (main capacity) |
+| `min_data_in_leaf` | 20 | 20-500 | Min samples per leaf |
+| `feature_fraction` | 1 | 0.5-0.8 | Feature sampling per tree |
+| `bagging_fraction` | 1 | 0.6-0.9 | Row sampling per tree |
+| `bagging_freq` | 0 | 1-5 | How often to subsample |
+| `lambda_l1` | 0 | 0-10 | L1 on leaf weights |
+| `lambda_l2` | 0 | 0-10 | L2 on leaf weights |
+| `min_gain_to_split` | 0 | 0-1 | Min split gain (like $\gamma$ in XGBoost) |
+| `max_depth` | $-1$ | $-1$ or 8-15 | Depth safety net |

--- a/ml-guides/gbm/images/bagging_vs_boosting.svg
+++ b/ml-guides/gbm/images/bagging_vs_boosting.svg
@@ -1,0 +1,97 @@
+<svg width="680" height="440" viewBox="0 0 680 440" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="680" height="440" fill="#FAFAF8" rx="8"/>
+
+  <!-- Bagging section label -->
+  <text x="170" y="30" text-anchor="middle" font-size="14" font-weight="500" fill="#2C2C2A">Bagging / random forest</text>
+  <text x="170" y="48" text-anchor="middle" font-size="12" fill="#5F5E5A">Independent, parallel</text>
+
+  <!-- Training data -->
+  <rect x="110" y="66" width="120" height="40" rx="8" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text x="170" y="90" text-anchor="middle" dominant-baseline="central" font-size="14" font-weight="500" fill="#2C2C2A">Training data</text>
+
+  <!-- Bootstrap arrows -->
+  <line x1="130" y1="106" x2="80" y2="140" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="170" y1="106" x2="170" y2="140" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="210" y1="106" x2="260" y2="140" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Bootstrap labels -->
+  <text x="90" y="122" text-anchor="middle" font-size="12" fill="#5F5E5A" transform="rotate(-20 90 122)">Sample 1</text>
+  <text x="260" y="122" text-anchor="middle" font-size="12" fill="#5F5E5A" transform="rotate(20 260 122)">Sample 3</text>
+
+  <!-- Trees -->
+  <rect x="40" y="144" width="80" height="40" rx="8" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="80" y="168" text-anchor="middle" dominant-baseline="central" font-size="14" font-weight="500" fill="#085041">Tree 1</text>
+
+  <rect x="130" y="144" width="80" height="40" rx="8" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="170" y="168" text-anchor="middle" dominant-baseline="central" font-size="14" font-weight="500" fill="#085041">Tree 2</text>
+
+  <rect x="220" y="144" width="80" height="40" rx="8" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="260" y="168" text-anchor="middle" dominant-baseline="central" font-size="14" font-weight="500" fill="#085041">Tree 3</text>
+
+  <!-- Arrows to average -->
+  <line x1="80" y1="184" x2="130" y2="218" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="170" y1="184" x2="170" y2="218" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="260" y1="184" x2="210" y2="218" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Average -->
+  <rect x="120" y="222" width="100" height="40" rx="8" fill="#EAF3DE" stroke="#3B6D11" stroke-width="0.5"/>
+  <text x="170" y="246" text-anchor="middle" dominant-baseline="central" font-size="14" font-weight="500" fill="#27500A">Average</text>
+
+  <!-- Final prediction -->
+  <line x1="170" y1="262" x2="170" y2="290" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <rect x="120" y="294" width="100" height="36" rx="8" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text x="170" y="316" text-anchor="middle" dominant-baseline="central" font-size="14" font-weight="500" fill="#2C2C2A">Prediction</text>
+
+  <!-- Separator -->
+  <line x1="340" y1="20" x2="340" y2="340" stroke="#B4B2A9" stroke-width="0.5" stroke-dasharray="4 4"/>
+
+  <!-- Boosting section label -->
+  <text x="510" y="30" text-anchor="middle" font-size="14" font-weight="500" fill="#2C2C2A">Gradient boosting</text>
+  <text x="510" y="48" text-anchor="middle" font-size="12" fill="#5F5E5A">Sequential, corrective</text>
+
+  <!-- Step 1 -->
+  <rect x="430" y="66" width="160" height="44" rx="8" fill="#EEEDFE" stroke="#534AB7" stroke-width="0.5"/>
+  <text x="510" y="82" text-anchor="middle" dominant-baseline="central" font-size="14" font-weight="500" fill="#3C3489">Tree 1</text>
+  <text x="510" y="100" text-anchor="middle" dominant-baseline="central" font-size="12" fill="#534AB7">Fits original target</text>
+
+  <!-- Residual arrow -->
+  <line x1="510" y1="110" x2="510" y2="136" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="580" y="126" text-anchor="start" font-size="12" fill="#5F5E5A">Compute residuals</text>
+
+  <!-- Step 2 -->
+  <rect x="430" y="140" width="160" height="44" rx="8" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text x="510" y="156" text-anchor="middle" dominant-baseline="central" font-size="14" font-weight="500" fill="#712B13">Tree 2</text>
+  <text x="510" y="174" text-anchor="middle" dominant-baseline="central" font-size="12" fill="#993C1D">Fits residuals of tree 1</text>
+
+  <!-- Residual arrow -->
+  <line x1="510" y1="184" x2="510" y2="210" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="580" y="200" text-anchor="start" font-size="12" fill="#5F5E5A">Compute residuals</text>
+
+  <!-- Step 3 -->
+  <rect x="430" y="214" width="160" height="44" rx="8" fill="#FAEEDA" stroke="#854F0B" stroke-width="0.5"/>
+  <text x="510" y="230" text-anchor="middle" dominant-baseline="central" font-size="14" font-weight="500" fill="#633806">Tree 3</text>
+  <text x="510" y="248" text-anchor="middle" dominant-baseline="central" font-size="12" fill="#854F0B">Fits residuals of 1+2</text>
+
+  <!-- Sum arrow -->
+  <line x1="510" y1="258" x2="510" y2="284" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Weighted sum -->
+  <rect x="440" y="288" width="140" height="40" rx="8" fill="#EAF3DE" stroke="#3B6D11" stroke-width="0.5"/>
+  <text x="510" y="312" text-anchor="middle" dominant-baseline="central" font-size="14" font-weight="500" fill="#27500A">Weighted sum</text>
+
+  <!-- Final prediction -->
+  <line x1="510" y1="328" x2="510" y2="356" stroke="#5F5E5A" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <rect x="460" y="360" width="100" height="36" rx="8" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text x="510" y="382" text-anchor="middle" dominant-baseline="central" font-size="14" font-weight="500" fill="#2C2C2A">Prediction</text>
+
+  <!-- Key difference annotations -->
+  <text x="170" y="360" text-anchor="middle" font-size="12" fill="#5F5E5A">Reduces variance</text>
+  <text x="510" y="412" text-anchor="middle" font-size="12" fill="#5F5E5A">Reduces bias</text>
+</svg>

--- a/ml-guides/gbm/images/gradient_boosting_residual_fitting.svg
+++ b/ml-guides/gbm/images/gradient_boosting_residual_fitting.svg
@@ -1,0 +1,61 @@
+<svg width="680" height="320" viewBox="0 0 680 320" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="680" height="320" fill="#FAFAF8" rx="8"/>
+
+  <!-- Title -->
+  <text x="340" y="28" text-anchor="middle" font-size="14" font-weight="500" fill="#2C2C2A">Gradient boosting residual fitting — reactor yield prediction</text>
+  <text x="340" y="46" text-anchor="middle" font-size="12" fill="#5F5E5A">Actual yield = 91.0%  |  Learning rate η = 0.3</text>
+
+  <!-- Round 0 -->
+  <rect x="20" y="66" width="200" height="100" rx="8" fill="#EEEDFE" stroke="#534AB7" stroke-width="0.5"/>
+  <text x="30" y="84" font-size="11" font-weight="500" fill="#534AB7" text-transform="uppercase" letter-spacing="0.5">Round 0 — Initialise</text>
+  <text x="30" y="104" font-size="13" font-weight="500" fill="#3C3489">Start with the mean</text>
+  <text x="30" y="124" font-size="12" fill="#5F5E5A" font-family="monospace">F₀ = mean(y) = 88.0</text>
+  <text x="30" y="144" font-size="12" fill="#5F5E5A" font-family="monospace">Residual = 91.0 − 88.0</text>
+  <text x="30" y="160" font-size="12" font-weight="500" fill="#0F6E56" font-family="monospace">         = +3.0</text>
+
+  <!-- Arrow -->
+  <line x1="224" y1="116" x2="238" y2="116" stroke="#5F5E5A" stroke-width="1"/>
+  <polygon points="238,112 246,116 238,120" fill="#5F5E5A"/>
+
+  <!-- Round 1 -->
+  <rect x="250" y="66" width="190" height="100" rx="8" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text x="260" y="84" font-size="11" font-weight="500" fill="#993C1D" text-transform="uppercase" letter-spacing="0.5">Round 1 — Tree 1</text>
+  <text x="260" y="104" font-size="13" font-weight="500" fill="#712B13">Fit residuals</text>
+  <text x="260" y="124" font-size="12" fill="#5F5E5A" font-family="monospace">Tree learns: +3.0</text>
+  <text x="260" y="140" font-size="12" fill="#5F5E5A" font-family="monospace">η × 3.0 = +0.9</text>
+  <text x="260" y="156" font-size="12" fill="#5F5E5A" font-family="monospace">F₁ = 88.0 + 0.9 = 88.9</text>
+
+  <!-- Arrow -->
+  <line x1="444" y1="116" x2="458" y2="116" stroke="#5F5E5A" stroke-width="1"/>
+  <polygon points="458,112 466,116 458,120" fill="#5F5E5A"/>
+
+  <!-- Round 2 -->
+  <rect x="470" y="66" width="190" height="100" rx="8" fill="#FAEEDA" stroke="#854F0B" stroke-width="0.5"/>
+  <text x="480" y="84" font-size="11" font-weight="500" fill="#854F0B" text-transform="uppercase" letter-spacing="0.5">Round 2 — Tree 2</text>
+  <text x="480" y="104" font-size="13" font-weight="500" fill="#633806">Fit remaining error</text>
+  <text x="480" y="124" font-size="12" fill="#5F5E5A" font-family="monospace">Tree learns: +2.1</text>
+  <text x="480" y="140" font-size="12" fill="#5F5E5A" font-family="monospace">η × 2.1 = +0.63</text>
+  <text x="480" y="156" font-size="12" fill="#5F5E5A" font-family="monospace">F₂ = 88.9 + 0.63 = 89.53</text>
+
+  <!-- Residual bars visualization -->
+  <text x="20" y="200" font-size="12" font-weight="500" fill="#2C2C2A">Residual shrinking over rounds:</text>
+
+  <!-- Bar labels -->
+  <text x="90" y="224" text-anchor="middle" font-size="11" fill="#5F5E5A">Round 0</text>
+  <text x="270" y="224" text-anchor="middle" font-size="11" fill="#5F5E5A">Round 1</text>
+  <text x="450" y="224" text-anchor="middle" font-size="11" fill="#5F5E5A">Round 2</text>
+
+  <!-- Bars (height proportional to residual) -->
+  <rect x="60" y="230" width="60" height="60" rx="4" fill="#534AB7" opacity="0.7"/>
+  <text x="90" y="264" text-anchor="middle" font-size="12" font-weight="500" fill="white">3.0</text>
+
+  <rect x="240" y="242" width="60" height="48" rx="4" fill="#993C1D" opacity="0.7"/>
+  <text x="270" y="270" text-anchor="middle" font-size="12" font-weight="500" fill="white">2.1</text>
+
+  <rect x="420" y="256" width="60" height="34" rx="4" fill="#854F0B" opacity="0.7"/>
+  <text x="450" y="277" text-anchor="middle" font-size="12" font-weight="500" fill="white">1.47</text>
+
+  <!-- Formula -->
+  <rect x="20" y="298" width="640" height="1" fill="#D3D1C7"/>
+  <text x="340" y="316" text-anchor="middle" font-size="12" fill="#5F5E5A" font-family="monospace">F_M(x) = mean(y) + η·h₁(x) + η·h₂(x) + … + η·h_M(x)</text>
+</svg>

--- a/ml-guides/gbm/images/levelwise_vs_leafwise_growth.svg
+++ b/ml-guides/gbm/images/levelwise_vs_leafwise_growth.svg
@@ -1,0 +1,117 @@
+<svg width="680" height="500" viewBox="0 0 680 500" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="680" height="500" fill="#FAFAF8" rx="8"/>
+
+  <!-- Level-wise section -->
+  <text x="340" y="28" text-anchor="middle" font-size="14" font-weight="500" fill="#2C2C2A">Level-wise growth (XGBoost default)</text>
+  <text x="340" y="46" text-anchor="middle" font-size="12" fill="#5F5E5A">Splits all nodes at each depth — produces balanced trees</text>
+
+  <!-- Root -->
+  <rect x="300" y="60" width="80" height="32" rx="6" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="340" y="80" text-anchor="middle" dominant-baseline="central" font-size="12" fill="#085041">Root</text>
+
+  <!-- Level 1 -->
+  <line x1="320" y1="92" x2="220" y2="112" stroke="#888780" stroke-width="0.5"/>
+  <line x1="360" y1="92" x2="460" y2="112" stroke="#888780" stroke-width="0.5"/>
+
+  <rect x="170" y="112" width="100" height="32" rx="6" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="220" y="132" text-anchor="middle" dominant-baseline="central" font-size="12" fill="#085041">Split 1</text>
+
+  <rect x="410" y="112" width="100" height="32" rx="6" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="460" y="132" text-anchor="middle" dominant-baseline="central" font-size="12" fill="#085041">Split 2</text>
+
+  <!-- Level 2 — all 4 nodes -->
+  <line x1="195" y1="144" x2="140" y2="168" stroke="#888780" stroke-width="0.5"/>
+  <line x1="245" y1="144" x2="300" y2="168" stroke="#888780" stroke-width="0.5"/>
+  <line x1="435" y1="144" x2="380" y2="168" stroke="#888780" stroke-width="0.5"/>
+  <line x1="485" y1="144" x2="540" y2="168" stroke="#888780" stroke-width="0.5"/>
+
+  <rect x="105" y="168" width="70" height="28" rx="6" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="140" y="186" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#085041">Leaf</text>
+
+  <rect x="265" y="168" width="70" height="28" rx="6" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="300" y="186" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#085041">Leaf</text>
+
+  <rect x="345" y="168" width="70" height="28" rx="6" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="380" y="186" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#085041">Leaf</text>
+
+  <rect x="505" y="168" width="70" height="28" rx="6" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="540" y="186" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#085041">Leaf</text>
+
+  <!-- Depth markers -->
+  <text x="80" y="80" text-anchor="end" font-size="11" fill="#888780">d = 0</text>
+  <text x="80" y="132" text-anchor="end" font-size="11" fill="#888780">d = 1</text>
+  <text x="80" y="186" text-anchor="end" font-size="11" fill="#888780">d = 2</text>
+
+  <text x="340" y="220" text-anchor="middle" font-size="12" fill="#5F5E5A">Balanced: all 4 leaves at same depth — uniform capacity allocation</text>
+
+  <!-- Separator -->
+  <line x1="40" y1="242" x2="640" y2="242" stroke="#D3D1C7" stroke-width="0.5" stroke-dasharray="4 4"/>
+
+  <!-- Leaf-wise section -->
+  <text x="340" y="270" text-anchor="middle" font-size="14" font-weight="500" fill="#2C2C2A">Leaf-wise growth (LightGBM default)</text>
+  <text x="340" y="288" text-anchor="middle" font-size="12" fill="#5F5E5A">Splits the single leaf with highest gain — produces unbalanced trees</text>
+
+  <!-- Step labels -->
+  <text x="56" y="326" text-anchor="end" font-size="11" fill="#888780">Step 1</text>
+  <text x="56" y="386" text-anchor="end" font-size="11" fill="#888780">Step 2</text>
+  <text x="56" y="446" text-anchor="end" font-size="11" fill="#888780">Step 3</text>
+
+  <!-- Step 1: Root splits -->
+  <rect x="80" y="310" width="60" height="28" rx="6" fill="#EEEDFE" stroke="#534AB7" stroke-width="0.5"/>
+  <text x="110" y="328" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#3C3489">Root</text>
+
+  <line x1="140" y1="324" x2="164" y2="324" stroke="#5F5E5A" stroke-width="1"/>
+  <polygon points="164,320 172,324 164,328" fill="#5F5E5A"/>
+
+  <rect x="178" y="310" width="60" height="28" rx="6" fill="#EEEDFE" stroke="#534AB7" stroke-width="0.5"/>
+  <text x="208" y="328" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#3C3489">A</text>
+
+  <rect x="250" y="310" width="60" height="28" rx="6" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text x="280" y="328" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#444441">B</text>
+
+  <!-- Gain labels -->
+  <text x="208" y="352" text-anchor="middle" font-size="11" font-weight="500" fill="#534AB7">Gain: 120</text>
+  <text x="280" y="352" text-anchor="middle" font-size="11" fill="#888780">Gain: 40</text>
+
+  <!-- Step 2: A splits (highest), B stays -->
+  <rect x="80" y="370" width="60" height="28" rx="6" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text x="110" y="388" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#712B13">A</text>
+
+  <line x1="140" y1="384" x2="164" y2="384" stroke="#5F5E5A" stroke-width="1"/>
+  <polygon points="164,380 172,384 164,388" fill="#5F5E5A"/>
+
+  <rect x="178" y="370" width="60" height="28" rx="6" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text x="208" y="388" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#712B13">A1</text>
+
+  <rect x="250" y="370" width="60" height="28" rx="6" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text x="280" y="388" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#712B13">A2</text>
+
+  <rect x="330" y="370" width="60" height="28" rx="6" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text x="360" y="388" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#444441">B</text>
+
+  <text x="208" y="412" text-anchor="middle" font-size="11" font-weight="500" fill="#993C1D">Gain: 85</text>
+  <text x="280" y="412" text-anchor="middle" font-size="11" fill="#888780">Gain: 30</text>
+  <text x="360" y="412" text-anchor="middle" font-size="11" fill="#888780">Gain: 40</text>
+
+  <!-- Step 3: A1 splits again -->
+  <rect x="80" y="430" width="60" height="28" rx="6" fill="#FAEEDA" stroke="#854F0B" stroke-width="0.5"/>
+  <text x="110" y="448" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#633806">A1</text>
+
+  <line x1="140" y1="444" x2="164" y2="444" stroke="#5F5E5A" stroke-width="1"/>
+  <polygon points="164,440 172,444 164,448" fill="#5F5E5A"/>
+
+  <rect x="178" y="430" width="60" height="28" rx="6" fill="#FAEEDA" stroke="#854F0B" stroke-width="0.5"/>
+  <text x="208" y="448" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#633806">A1a</text>
+
+  <rect x="250" y="430" width="60" height="28" rx="6" fill="#FAEEDA" stroke="#854F0B" stroke-width="0.5"/>
+  <text x="280" y="448" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#633806">A1b</text>
+
+  <rect x="330" y="430" width="60" height="28" rx="6" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text x="360" y="448" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#444441">A2</text>
+
+  <rect x="410" y="430" width="60" height="28" rx="6" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text x="440" y="448" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#444441">B</text>
+
+  <!-- Annotation -->
+  <text x="340" y="482" text-anchor="middle" font-size="12" fill="#5F5E5A">Unbalanced: depth 3 on left, depth 1 on right — capacity goes where gain is highest</text>
+</svg>

--- a/ml-guides/gbm/images/timeseries_to_supervised_learning.svg
+++ b/ml-guides/gbm/images/timeseries_to_supervised_learning.svg
@@ -1,0 +1,142 @@
+<svg width="680" height="520" viewBox="0 0 680 520" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="680" height="520" fill="#FAFAF8" rx="8"/>
+
+  <!-- Title -->
+  <text x="340" y="24" text-anchor="middle" font-size="14" font-weight="500" fill="#2C2C2A">Converting time series to supervised learning</text>
+  <text x="340" y="42" text-anchor="middle" font-size="12" fill="#5F5E5A">Prediction at t = 12:00, horizon h = 2h → predict temperature at 14:00</text>
+
+  <!-- Raw time series section -->
+  <text x="30" y="72" font-size="12" font-weight="500" fill="#2C2C2A">Raw time series (reactor outlet temperature, hourly)</text>
+
+  <!-- Time series bar -->
+  <rect x="30" y="82" width="620" height="36" rx="6" fill="#F1EFE8" stroke="#D3D1C7" stroke-width="0.5"/>
+
+  <!-- Time labels and values -->
+  <text x="74" y="96" text-anchor="middle" font-size="10" fill="#888780">08:00</text>
+  <text x="74" y="111" text-anchor="middle" font-size="12" font-weight="500" fill="#2C2C2A">382</text>
+
+  <text x="163" y="96" text-anchor="middle" font-size="10" fill="#888780">09:00</text>
+  <text x="163" y="111" text-anchor="middle" font-size="12" font-weight="500" fill="#2C2C2A">385</text>
+
+  <text x="252" y="96" text-anchor="middle" font-size="10" fill="#888780">10:00</text>
+  <text x="252" y="111" text-anchor="middle" font-size="12" font-weight="500" fill="#2C2C2A">384</text>
+
+  <text x="341" y="96" text-anchor="middle" font-size="10" fill="#888780">11:00</text>
+  <text x="341" y="111" text-anchor="middle" font-size="12" font-weight="500" fill="#2C2C2A">388</text>
+
+  <!-- Prediction time highlighted -->
+  <rect x="397" y="84" width="68" height="32" rx="4" fill="#E6F1FB" stroke="#185FA5" stroke-width="0.5"/>
+  <text x="431" y="96" text-anchor="middle" font-size="10" fill="#185FA5">12:00</text>
+  <text x="431" y="111" text-anchor="middle" font-size="12" font-weight="500" fill="#0C447C">390</text>
+
+  <text x="520" y="96" text-anchor="middle" font-size="10" fill="#888780">13:00</text>
+  <text x="520" y="111" text-anchor="middle" font-size="12" font-weight="500" fill="#2C2C2A">387</text>
+
+  <!-- Target time highlighted in red -->
+  <rect x="575" y="84" width="68" height="32" rx="4" fill="#FCEBEB" stroke="#A32D2D" stroke-width="0.5"/>
+  <text x="609" y="96" text-anchor="middle" font-size="10" fill="#A32D2D">14:00</text>
+  <text x="609" y="111" text-anchor="middle" font-size="12" font-weight="500" fill="#791F1F">391</text>
+
+  <!-- Labels for highlighted times -->
+  <text x="431" y="132" text-anchor="middle" font-size="10" font-weight="500" fill="#185FA5">Prediction time</text>
+  <text x="609" y="132" text-anchor="middle" font-size="10" font-weight="500" fill="#A32D2D">Target time</text>
+
+  <!-- Feature table section -->
+  <text x="30" y="162" font-size="12" font-weight="500" fill="#2C2C2A">Supervised learning row — features available at 12:00</text>
+
+  <!-- Table header -->
+  <rect x="30" y="172" width="620" height="26" rx="4" fill="#F1EFE8"/>
+  <text x="100" y="189" text-anchor="middle" font-size="11" font-weight="500" fill="#5F5E5A">Type</text>
+  <text x="260" y="189" text-anchor="middle" font-size="11" font-weight="500" fill="#5F5E5A">Feature</text>
+  <text x="420" y="189" text-anchor="middle" font-size="11" font-weight="500" fill="#5F5E5A">Value</text>
+  <text x="560" y="189" text-anchor="middle" font-size="11" font-weight="500" fill="#5F5E5A">Source</text>
+
+  <!-- Row 1: Lag -->
+  <rect x="30" y="200" width="620" height="26" rx="0" fill="none"/>
+  <rect x="55" y="204" width="90" height="18" rx="4" fill="#E6F1FB"/>
+  <text x="100" y="217" text-anchor="middle" font-size="11" fill="#0C447C">Lag</text>
+  <text x="260" y="217" text-anchor="middle" font-size="11" fill="#0C447C" font-family="monospace">temp_lag_1h</text>
+  <text x="420" y="217" text-anchor="middle" font-size="11" fill="#2C2C2A">387</text>
+  <text x="560" y="217" text-anchor="middle" font-size="11" fill="#5F5E5A">t−1 = 11:00</text>
+
+  <!-- Row 2: Lag -->
+  <rect x="30" y="228" width="620" height="26" rx="0" fill="#FAFAF8"/>
+  <rect x="55" y="232" width="90" height="18" rx="4" fill="#E6F1FB"/>
+  <text x="100" y="245" text-anchor="middle" font-size="11" fill="#0C447C">Lag</text>
+  <text x="260" y="245" text-anchor="middle" font-size="11" fill="#0C447C" font-family="monospace">temp_lag_2h</text>
+  <text x="420" y="245" text-anchor="middle" font-size="11" fill="#2C2C2A">388</text>
+  <text x="560" y="245" text-anchor="middle" font-size="11" fill="#5F5E5A">t−2 = 10:00</text>
+
+  <!-- Row 3: Lag -->
+  <rect x="30" y="256" width="620" height="26" rx="0" fill="none"/>
+  <rect x="55" y="260" width="90" height="18" rx="4" fill="#E6F1FB"/>
+  <text x="100" y="273" text-anchor="middle" font-size="11" fill="#0C447C">Lag</text>
+  <text x="260" y="273" text-anchor="middle" font-size="11" fill="#0C447C" font-family="monospace">temp_lag_4h</text>
+  <text x="420" y="273" text-anchor="middle" font-size="11" fill="#2C2C2A">385</text>
+  <text x="560" y="273" text-anchor="middle" font-size="11" fill="#5F5E5A">t−4 = 08:00</text>
+
+  <!-- Row 4: Rolling -->
+  <rect x="30" y="284" width="620" height="26" rx="0" fill="#FAFAF8"/>
+  <rect x="55" y="288" width="90" height="18" rx="4" fill="#E1F5EE"/>
+  <text x="100" y="301" text-anchor="middle" font-size="11" fill="#085041">Rolling</text>
+  <text x="260" y="301" text-anchor="middle" font-size="11" fill="#085041" font-family="monospace">temp_mean_3h</text>
+  <text x="420" y="301" text-anchor="middle" font-size="11" fill="#2C2C2A">387.3</text>
+  <text x="560" y="301" text-anchor="middle" font-size="11" fill="#5F5E5A">10:00–12:00</text>
+
+  <!-- Row 5: Rolling -->
+  <rect x="30" y="312" width="620" height="26" rx="0" fill="none"/>
+  <rect x="55" y="316" width="90" height="18" rx="4" fill="#E1F5EE"/>
+  <text x="100" y="329" text-anchor="middle" font-size="11" fill="#085041">Rolling</text>
+  <text x="260" y="329" text-anchor="middle" font-size="11" fill="#085041" font-family="monospace">temp_std_3h</text>
+  <text x="420" y="329" text-anchor="middle" font-size="11" fill="#2C2C2A">2.5</text>
+  <text x="560" y="329" text-anchor="middle" font-size="11" fill="#5F5E5A">10:00–12:00</text>
+
+  <!-- Row 6: Calendar (known future) -->
+  <rect x="30" y="340" width="620" height="26" rx="0" fill="#FAFAF8"/>
+  <rect x="55" y="344" width="90" height="18" rx="4" fill="#FAEEDA"/>
+  <text x="100" y="357" text-anchor="middle" font-size="11" fill="#633806">Calendar</text>
+  <text x="260" y="357" text-anchor="middle" font-size="11" fill="#633806" font-family="monospace">hour_of_day</text>
+  <text x="420" y="357" text-anchor="middle" font-size="11" fill="#2C2C2A">14</text>
+  <text x="560" y="357" text-anchor="middle" font-size="11" fill="#854F0B">Target time (known)</text>
+
+  <!-- Row 7: Calendar -->
+  <rect x="30" y="368" width="620" height="26" rx="0" fill="none"/>
+  <rect x="55" y="372" width="90" height="18" rx="4" fill="#FAEEDA"/>
+  <text x="100" y="385" text-anchor="middle" font-size="11" fill="#633806">Calendar</text>
+  <text x="260" y="385" text-anchor="middle" font-size="11" fill="#633806" font-family="monospace">is_day_shift</text>
+  <text x="420" y="385" text-anchor="middle" font-size="11" fill="#2C2C2A">1</text>
+  <text x="560" y="385" text-anchor="middle" font-size="11" fill="#854F0B">Target time (known)</text>
+
+  <!-- Row 8: LEAKAGE -->
+  <rect x="30" y="396" width="620" height="26" rx="0" fill="#FCEBEB"/>
+  <rect x="55" y="400" width="90" height="18" rx="4" fill="#F09595"/>
+  <text x="100" y="413" text-anchor="middle" font-size="11" font-weight="500" fill="#501313">LEAKAGE</text>
+  <text x="260" y="413" text-anchor="middle" font-size="11" fill="#791F1F" font-family="monospace" text-decoration="line-through">temp_lag_0h</text>
+  <text x="420" y="413" text-anchor="middle" font-size="11" fill="#791F1F" text-decoration="line-through">391</text>
+  <text x="560" y="413" text-anchor="middle" font-size="11" fill="#791F1F">14:00 (future!)</text>
+
+  <!-- Row 9: Target -->
+  <rect x="30" y="424" width="620" height="26" rx="0" fill="none"/>
+  <rect x="55" y="428" width="90" height="18" rx="4" fill="#F1EFE8" stroke="#5F5E5A" stroke-width="0.5"/>
+  <text x="100" y="441" text-anchor="middle" font-size="11" font-weight="500" fill="#2C2C2A">Target</text>
+  <text x="260" y="441" text-anchor="middle" font-size="11" font-weight="500" fill="#2C2C2A" font-family="monospace">temp_at_t+2h</text>
+  <text x="420" y="441" text-anchor="middle" font-size="11" font-weight="500" fill="#2C2C2A">391</text>
+  <text x="560" y="441" text-anchor="middle" font-size="11" fill="#5F5E5A">14:00</text>
+
+  <!-- Legend -->
+  <rect x="30" y="462" width="620" height="1" fill="#D3D1C7"/>
+
+  <rect x="30" y="476" width="12" height="12" rx="2" fill="#E6F1FB" stroke="#185FA5" stroke-width="0.5"/>
+  <text x="48" y="487" font-size="11" fill="#5F5E5A">Lag features (past values)</text>
+
+  <rect x="200" y="476" width="12" height="12" rx="2" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="218" y="487" font-size="11" fill="#5F5E5A">Rolling window stats</text>
+
+  <rect x="360" y="476" width="12" height="12" rx="2" fill="#FAEEDA" stroke="#854F0B" stroke-width="0.5"/>
+  <text x="378" y="487" font-size="11" fill="#5F5E5A">Known future covariates</text>
+
+  <rect x="540" y="476" width="12" height="12" rx="2" fill="#FCEBEB" stroke="#A32D2D" stroke-width="0.5"/>
+  <text x="558" y="487" font-size="11" fill="#5F5E5A">Leakage</text>
+
+  <text x="340" y="510" text-anchor="middle" font-size="11" fill="#5F5E5A">Calendar features use the target time (14:00) — this is NOT leakage because we know what hour it will be.</text>
+</svg>

--- a/ml-guides/gbm/images/walkforward_validation.svg
+++ b/ml-guides/gbm/images/walkforward_validation.svg
@@ -1,0 +1,82 @@
+<svg width="680" height="360" viewBox="0 0 680 360" xmlns="http://www.w3.org/2000/svg" font-family="system-ui, -apple-system, sans-serif">
+  <rect width="680" height="360" fill="#FAFAF8" rx="8"/>
+
+  <!-- Time axis -->
+  <line x1="60" y1="30" x2="620" y2="30" stroke="#444441" stroke-width="0.5"/>
+  <text x="60" y="20" text-anchor="middle" font-size="11" fill="#5F5E5A">Jan 2022</text>
+  <text x="200" y="20" text-anchor="middle" font-size="11" fill="#5F5E5A">Jul 2022</text>
+  <text x="340" y="20" text-anchor="middle" font-size="11" fill="#5F5E5A">Jan 2023</text>
+  <text x="480" y="20" text-anchor="middle" font-size="11" fill="#5F5E5A">Jul 2023</text>
+  <text x="620" y="20" text-anchor="middle" font-size="11" fill="#5F5E5A">Jan 2024</text>
+
+  <!-- Tick marks -->
+  <line x1="60" y1="26" x2="60" y2="34" stroke="#444441" stroke-width="0.5"/>
+  <line x1="200" y1="26" x2="200" y2="34" stroke="#444441" stroke-width="0.5"/>
+  <line x1="340" y1="26" x2="340" y2="34" stroke="#444441" stroke-width="0.5"/>
+  <line x1="480" y1="26" x2="480" y2="34" stroke="#444441" stroke-width="0.5"/>
+  <line x1="620" y1="26" x2="620" y2="34" stroke="#444441" stroke-width="0.5"/>
+
+  <!-- Fold 1 -->
+  <text x="48" y="68" text-anchor="end" font-size="12" fill="#5F5E5A">Fold 1</text>
+  <rect x="60" y="52" width="280" height="28" rx="4" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="200" y="70" text-anchor="middle" dominant-baseline="central" font-size="12" fill="#085041">Train</text>
+
+  <rect x="340" y="52" width="140" height="28" rx="4" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text x="410" y="70" text-anchor="middle" dominant-baseline="central" font-size="12" fill="#712B13">Validate</text>
+
+  <rect x="480" y="52" width="140" height="28" rx="4" fill="#F1EFE8" stroke="#D3D1C7" stroke-width="0.5" opacity="0.5"/>
+  <text x="550" y="70" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#B4B2A9">Unseen</text>
+
+  <!-- Fold 2 -->
+  <text x="48" y="118" text-anchor="end" font-size="12" fill="#5F5E5A">Fold 2</text>
+  <rect x="60" y="102" width="420" height="28" rx="4" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="270" y="120" text-anchor="middle" dominant-baseline="central" font-size="12" fill="#085041">Train (expanded)</text>
+
+  <rect x="480" y="102" width="140" height="28" rx="4" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text x="550" y="120" text-anchor="middle" dominant-baseline="central" font-size="12" fill="#712B13">Validate</text>
+
+  <!-- Sliding window variant label -->
+  <text x="340" y="160" text-anchor="middle" font-size="13" font-weight="500" fill="#2C2C2A">Sliding window variant</text>
+
+  <!-- Fold 3 -->
+  <text x="48" y="188" text-anchor="end" font-size="12" fill="#5F5E5A">Fold 3</text>
+
+  <rect x="60" y="172" width="140" height="28" rx="4" fill="#F1EFE8" stroke="#D3D1C7" stroke-width="0.5" opacity="0.5"/>
+  <text x="130" y="190" text-anchor="middle" dominant-baseline="central" font-size="11" fill="#B4B2A9">Dropped</text>
+
+  <rect x="200" y="172" width="280" height="28" rx="4" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="340" y="190" text-anchor="middle" dominant-baseline="central" font-size="12" fill="#085041">Train (6 months)</text>
+
+  <rect x="480" y="172" width="140" height="28" rx="4" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text x="550" y="190" text-anchor="middle" dominant-baseline="central" font-size="12" fill="#712B13">Validate</text>
+
+  <!-- Wrong approach section -->
+  <rect x="30" y="220" width="620" height="1" fill="#D3D1C7"/>
+  <text x="340" y="246" text-anchor="middle" font-size="13" font-weight="500" fill="#A32D2D">✗  What NOT to do: random train/test split</text>
+
+  <!-- Random interleaved blocks -->
+  <text x="48" y="278" text-anchor="end" font-size="12" fill="#A32D2D">Wrong</text>
+
+  <rect x="60" y="262" width="50" height="28" rx="4" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <rect x="110" y="262" width="30" height="28" rx="4" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <rect x="140" y="262" width="70" height="28" rx="4" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <rect x="210" y="262" width="40" height="28" rx="4" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <rect x="250" y="262" width="60" height="28" rx="4" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <rect x="310" y="262" width="30" height="28" rx="4" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <rect x="340" y="262" width="90" height="28" rx="4" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <rect x="430" y="262" width="50" height="28" rx="4" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <rect x="480" y="262" width="80" height="28" rx="4" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <rect x="560" y="262" width="60" height="28" rx="4" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+
+  <!-- Explanation -->
+  <text x="340" y="310" text-anchor="middle" font-size="12" fill="#5F5E5A">Model sees future data in training — exploits autocorrelation</text>
+  <text x="340" y="326" text-anchor="middle" font-size="12" fill="#5F5E5A">Validation error is wildly optimistic</text>
+
+  <!-- Legend -->
+  <rect x="180" y="346" width="12" height="12" rx="2" fill="#E1F5EE" stroke="#0F6E56" stroke-width="0.5"/>
+  <text x="198" y="356" font-size="11" fill="#5F5E5A">Train</text>
+  <rect x="240" y="346" width="12" height="12" rx="2" fill="#FAECE7" stroke="#993C1D" stroke-width="0.5"/>
+  <text x="258" y="356" font-size="11" fill="#5F5E5A">Validate</text>
+  <rect x="310" y="346" width="12" height="12" rx="2" fill="#F1EFE8" stroke="#D3D1C7" stroke-width="0.5" opacity="0.5"/>
+  <text x="328" y="356" font-size="11" fill="#5F5E5A">Unseen / dropped</text>
+</svg>

--- a/ml-guides/nam/images/ch2-nam-architecture.svg
+++ b/ml-guides/nam/images/ch2-nam-architecture.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" font-family="Arial, sans-serif">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#555"/>
+    </marker>
+  </defs>
+  
+  <!-- Title -->
+  <text x="400" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#222">Neural Additive Model (NAM) Architecture</text>
+  
+  <!-- Input features -->
+  <rect x="30" y="380" width="60" height="35" rx="5" fill="#E3F2FD" stroke="#1565C0" stroke-width="1.5"/>
+  <text x="60" y="402" text-anchor="middle" font-size="13" fill="#1565C0" font-weight="bold">x₁</text>
+  
+  <rect x="150" y="380" width="60" height="35" rx="5" fill="#E3F2FD" stroke="#1565C0" stroke-width="1.5"/>
+  <text x="180" y="402" text-anchor="middle" font-size="13" fill="#1565C0" font-weight="bold">x₂</text>
+  
+  <text x="295" y="402" text-anchor="middle" font-size="20" fill="#888">⋯</text>
+  
+  <rect x="370" y="380" width="60" height="35" rx="5" fill="#E3F2FD" stroke="#1565C0" stroke-width="1.5"/>
+  <text x="400" y="402" text-anchor="middle" font-size="13" fill="#1565C0" font-weight="bold">xₖ</text>
+  
+  <!-- Feature Networks -->
+  <rect x="15" y="240" width="90" height="100" rx="8" fill="#FFF3E0" stroke="#E65100" stroke-width="1.5"/>
+  <text x="60" y="270" text-anchor="middle" font-size="11" fill="#E65100" font-weight="bold">Feature</text>
+  <text x="60" y="285" text-anchor="middle" font-size="11" fill="#E65100" font-weight="bold">Net 1</text>
+  <text x="60" y="305" text-anchor="middle" font-size="9" fill="#888">(DNN or ExU)</text>
+  <text x="60" y="325" text-anchor="middle" font-size="12" fill="#E65100">f₁(x₁)</text>
+  
+  <rect x="135" y="240" width="90" height="100" rx="8" fill="#FFF3E0" stroke="#E65100" stroke-width="1.5"/>
+  <text x="180" y="270" text-anchor="middle" font-size="11" fill="#E65100" font-weight="bold">Feature</text>
+  <text x="180" y="285" text-anchor="middle" font-size="11" fill="#E65100" font-weight="bold">Net 2</text>
+  <text x="180" y="305" text-anchor="middle" font-size="9" fill="#888">(DNN or ExU)</text>
+  <text x="180" y="325" text-anchor="middle" font-size="12" fill="#E65100">f₂(x₂)</text>
+  
+  <text x="295" y="295" text-anchor="middle" font-size="20" fill="#888">⋯</text>
+  
+  <rect x="355" y="240" width="90" height="100" rx="8" fill="#FFF3E0" stroke="#E65100" stroke-width="1.5"/>
+  <text x="400" y="270" text-anchor="middle" font-size="11" fill="#E65100" font-weight="bold">Feature</text>
+  <text x="400" y="285" text-anchor="middle" font-size="11" fill="#E65100" font-weight="bold">Net K</text>
+  <text x="400" y="305" text-anchor="middle" font-size="9" fill="#888">(DNN or ExU)</text>
+  <text x="400" y="325" text-anchor="middle" font-size="12" fill="#E65100">fₖ(xₖ)</text>
+  
+  <!-- Arrows from inputs to feature nets -->
+  <line x1="60" y1="380" x2="60" y2="345" stroke="#555" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="180" y1="380" x2="180" y2="345" stroke="#555" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="400" y1="380" x2="400" y2="345" stroke="#555" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  
+  <!-- Summation node -->
+  <circle cx="230" cy="170" r="28" fill="#E8F5E9" stroke="#2E7D32" stroke-width="2"/>
+  <text x="230" y="177" text-anchor="middle" font-size="22" fill="#2E7D32" font-weight="bold">Σ</text>
+  
+  <!-- Arrows from feature nets to sum -->
+  <line x1="60" y1="240" x2="210" y2="190" stroke="#555" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="180" y1="240" x2="225" y2="200" stroke="#555" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  <line x1="400" y1="240" x2="252" y2="190" stroke="#555" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  
+  <!-- Bias -->
+  <rect x="310" y="155" width="50" height="30" rx="5" fill="#F3E5F5" stroke="#6A1B9A" stroke-width="1.5"/>
+  <text x="335" y="175" text-anchor="middle" font-size="13" fill="#6A1B9A" font-weight="bold">β</text>
+  <line x1="310" y1="170" x2="260" y2="170" stroke="#555" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  
+  <!-- Link function -->
+  <rect x="195" y="80" width="70" height="35" rx="8" fill="#FCE4EC" stroke="#C62828" stroke-width="1.5"/>
+  <text x="230" y="102" text-anchor="middle" font-size="13" fill="#C62828" font-weight="bold">g⁻¹(·)</text>
+  
+  <line x1="230" y1="142" x2="230" y2="118" stroke="#555" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  
+  <!-- Output -->
+  <rect x="200" y="40" width="60" height="30" rx="5" fill="#E0E0E0" stroke="#333" stroke-width="1.5"/>
+  <text x="230" y="60" text-anchor="middle" font-size="13" fill="#333" font-weight="bold">ŷ</text>
+  <line x1="230" y1="80" x2="230" y2="73" stroke="#555" stroke-width="1.5" marker-end="url(#arrowhead)"/>
+  
+  <!-- Legend / annotation -->
+  <rect x="510" y="80" width="270" height="200" rx="8" fill="#FAFAFA" stroke="#CCC" stroke-width="1"/>
+  <text x="645" y="105" text-anchor="middle" font-size="13" font-weight="bold" fill="#333">Key Properties</text>
+  <text x="525" y="130" font-size="11" fill="#555">• Each feature net sees only 1 input</text>
+  <text x="525" y="150" font-size="11" fill="#555">• Nets trained jointly via backprop</text>
+  <text x="525" y="170" font-size="11" fill="#555">• Outputs summed (additive)</text>
+  <text x="525" y="190" font-size="11" fill="#555">• Shape functions: plot fₖ(xₖ) vs xₖ</text>
+  <text x="525" y="210" font-size="11" fill="#555">• g⁻¹ = identity (regression)</text>
+  <text x="525" y="230" font-size="11" fill="#555">• g⁻¹ = sigmoid (classification)</text>
+  <text x="525" y="255" font-size="11" fill="#E65100" font-weight="bold">No feature interactions by design</text>
+  
+  <!-- Equation at bottom -->
+  <text x="400" y="475" text-anchor="middle" font-size="14" fill="#333">g(E[y]) = β + f₁(x₁) + f₂(x₂) + ⋯ + fₖ(xₖ)   [Eq. 1]</text>
+</svg>

--- a/ml-guides/nam/images/ch3-tft-architecture.svg
+++ b/ml-guides/nam/images/ch3-tft-architecture.svg
@@ -1,0 +1,126 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 700" font-family="Arial, sans-serif">
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#555"/>
+    </marker>
+    <linearGradient id="pastGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#E3F2FD"/><stop offset="100%" stop-color="#BBDEFB"/>
+    </linearGradient>
+    <linearGradient id="futureGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFF3E0"/><stop offset="100%" stop-color="#FFE0B2"/>
+    </linearGradient>
+  </defs>
+
+  <text x="450" y="28" text-anchor="middle" font-size="17" font-weight="bold" fill="#222">Temporal Fusion Transformer — Data Flow</text>
+
+  <!-- Quantile Outputs -->
+  <rect x="310" y="42" width="280" height="32" rx="6" fill="#E8EAF6" stroke="#283593" stroke-width="1.5"/>
+  <text x="450" y="63" text-anchor="middle" font-size="12" fill="#283593" font-weight="bold">Quantile Outputs: ŷ(q, t, τ) = Wq·ψ̃ + bq  [Eq 23]</text>
+  <line x1="450" y1="74" x2="450" y2="90" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+
+  <!-- Position-wise Feed-Forward + Skip -->
+  <rect x="300" y="92" width="300" height="28" rx="5" fill="#F3E5F5" stroke="#6A1B9A" stroke-width="1.2"/>
+  <text x="450" y="111" text-anchor="middle" font-size="11" fill="#6A1B9A">Position-wise Feed-Forward (GRN) + Gated Skip [Eqs 21-22]</text>
+  <line x1="450" y1="120" x2="450" y2="136" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+
+  <!-- Self-Attention -->
+  <rect x="280" y="138" width="340" height="32" rx="5" fill="#FCE4EC" stroke="#C62828" stroke-width="1.5"/>
+  <text x="450" y="159" text-anchor="middle" font-size="11" fill="#C62828" font-weight="bold">Interpretable Multi-Head Attention (masked) [Eqs 13-16, 19-20]</text>
+  <line x1="450" y1="170" x2="450" y2="186" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+
+  <!-- Static Enrichment -->
+  <rect x="300" y="188" width="300" height="28" rx="5" fill="#E8F5E9" stroke="#2E7D32" stroke-width="1.2"/>
+  <text x="450" y="207" text-anchor="middle" font-size="11" fill="#2E7D32">Static Enrichment: GRN(φ̃, c_e) [Eq 18]</text>
+  <line x1="450" y1="216" x2="450" y2="232" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+
+  <!-- c_e arrow from static encoders -->
+  <line x1="130" y1="202" x2="298" y2="202" stroke="#2E7D32" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr)"/>
+  <text x="210" y="196" text-anchor="middle" font-size="9" fill="#2E7D32">c_e</text>
+
+  <!-- Gated Skip over LSTM -->
+  <rect x="300" y="234" width="300" height="28" rx="5" fill="#FFFDE7" stroke="#F57F17" stroke-width="1.2"/>
+  <text x="450" y="253" text-anchor="middle" font-size="11" fill="#F57F17">Gated Skip Connection + LayerNorm [Eq 17]</text>
+  <line x1="450" y1="262" x2="450" y2="278" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+
+  <!-- LSTM Encoder-Decoder -->
+  <rect x="200" y="280" width="190" height="50" rx="6" fill="url(#pastGrad)" stroke="#1565C0" stroke-width="1.5"/>
+  <text x="295" y="300" text-anchor="middle" font-size="11" fill="#1565C0" font-weight="bold">LSTM Encoder</text>
+  <text x="295" y="318" text-anchor="middle" font-size="9" fill="#555">Past inputs ξ̃_{t-k:t}</text>
+
+  <rect x="510" y="280" width="190" height="50" rx="6" fill="url(#futureGrad)" stroke="#E65100" stroke-width="1.5"/>
+  <text x="605" y="300" text-anchor="middle" font-size="11" fill="#E65100" font-weight="bold">LSTM Decoder</text>
+  <text x="605" y="318" text-anchor="middle" font-size="9" fill="#555">Future inputs ξ̃_{t+1:t+τ}</text>
+
+  <!-- Arrow between encoder and decoder -->
+  <line x1="392" y1="305" x2="508" y2="305" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+
+  <!-- c_c, c_h arrows -->
+  <line x1="130" y1="305" x2="198" y2="305" stroke="#1565C0" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr)"/>
+  <text x="164" y="298" text-anchor="middle" font-size="9" fill="#1565C0">c_c, c_h</text>
+
+  <!-- Arrows up from LSTMs -->
+  <line x1="295" y1="280" x2="380" y2="264" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+  <line x1="605" y1="280" x2="520" y2="264" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+
+  <!-- Variable Selection Networks -->
+  <rect x="200" y="360" width="190" height="45" rx="6" fill="#E3F2FD" stroke="#1565C0" stroke-width="1.5"/>
+  <text x="295" y="380" text-anchor="middle" font-size="11" fill="#1565C0" font-weight="bold">Variable Selection</text>
+  <text x="295" y="395" text-anchor="middle" font-size="9" fill="#555">(Past) [Eqs 6-8]</text>
+
+  <rect x="510" y="360" width="190" height="45" rx="6" fill="#FFF3E0" stroke="#E65100" stroke-width="1.5"/>
+  <text x="605" y="380" text-anchor="middle" font-size="11" fill="#E65100" font-weight="bold">Variable Selection</text>
+  <text x="605" y="395" text-anchor="middle" font-size="9" fill="#555">(Future) [Eqs 6-8]</text>
+
+  <!-- c_s arrows -->
+  <line x1="130" y1="380" x2="198" y2="380" stroke="#0D47A1" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr)"/>
+  <text x="164" y="373" text-anchor="middle" font-size="9" fill="#0D47A1">c_s</text>
+  <line x1="130" y1="385" x2="508" y2="385" stroke="#0D47A1" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arr)"/>
+
+  <!-- Arrows from VarSel to LSTM -->
+  <line x1="295" y1="360" x2="295" y2="332" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+  <line x1="605" y1="360" x2="605" y2="332" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+
+  <!-- Static Covariate Encoders -->
+  <rect x="30" y="260" width="120" height="140" rx="6" fill="#E0F7FA" stroke="#00695C" stroke-width="1.5"/>
+  <text x="90" y="285" text-anchor="middle" font-size="11" fill="#00695C" font-weight="bold">Static</text>
+  <text x="90" y="300" text-anchor="middle" font-size="11" fill="#00695C" font-weight="bold">Covariate</text>
+  <text x="90" y="315" text-anchor="middle" font-size="11" fill="#00695C" font-weight="bold">Encoders</text>
+  <text x="90" y="340" text-anchor="middle" font-size="9" fill="#555">→ c_s (var sel)</text>
+  <text x="90" y="355" text-anchor="middle" font-size="9" fill="#555">→ c_e (enrich)</text>
+  <text x="90" y="370" text-anchor="middle" font-size="9" fill="#555">→ c_c (cell init)</text>
+  <text x="90" y="385" text-anchor="middle" font-size="9" fill="#555">→ c_h (hidden init)</text>
+
+  <!-- Static VarSel -->
+  <rect x="30" y="420" width="120" height="40" rx="6" fill="#E0F7FA" stroke="#00695C" stroke-width="1.2"/>
+  <text x="90" y="440" text-anchor="middle" font-size="10" fill="#00695C" font-weight="bold">Var Sel (Static)</text>
+  <text x="90" y="453" text-anchor="middle" font-size="9" fill="#555">[Eqs 6-8]</text>
+  <line x1="90" y1="420" x2="90" y2="402" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+
+  <!-- Input layer -->
+  <rect x="15" y="480" width="150" height="35" rx="5" fill="#B2DFDB" stroke="#00695C" stroke-width="1.2"/>
+  <text x="90" y="502" text-anchor="middle" font-size="11" fill="#00695C" font-weight="bold">S: Static Metadata</text>
+  <line x1="90" y1="480" x2="90" y2="462" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+
+  <rect x="200" y="430" width="190" height="35" rx="5" fill="#BBDEFB" stroke="#1565C0" stroke-width="1.2"/>
+  <text x="295" y="452" text-anchor="middle" font-size="11" fill="#1565C0" font-weight="bold">χ_{t-k}, …, χ_t : Past Inputs</text>
+  <line x1="295" y1="430" x2="295" y2="407" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+
+  <rect x="510" y="430" width="190" height="35" rx="5" fill="#FFE0B2" stroke="#E65100" stroke-width="1.2"/>
+  <text x="605" y="452" text-anchor="middle" font-size="11" fill="#E65100" font-weight="bold">x_{t+1}, …, x_{t+τ} : Future</text>
+  <line x1="605" y1="430" x2="605" y2="407" stroke="#555" stroke-width="1.2" marker-end="url(#arr)"/>
+
+  <!-- Big gated skip arrow on the right -->
+  <path d="M 620 234 L 750 234 L 750 92 L 602 92" stroke="#F57F17" stroke-width="1.5" fill="none" stroke-dasharray="6,3" marker-end="url(#arr)"/>
+  <text x="762" y="170" text-anchor="start" font-size="9" fill="#F57F17" transform="rotate(-90,762,170)">Gated skip over</text>
+  <text x="776" y="170" text-anchor="start" font-size="9" fill="#F57F17" transform="rotate(-90,776,170)">entire Transformer</text>
+
+  <!-- Legend -->
+  <rect x="520" y="530" width="350" height="145" rx="6" fill="#FAFAFA" stroke="#CCC" stroke-width="1"/>
+  <text x="695" y="552" text-anchor="middle" font-size="12" font-weight="bold" fill="#333">TFT Component Summary</text>
+  <text x="535" y="572" font-size="10" fill="#C62828">■</text><text x="550" y="572" font-size="10" fill="#555">Interpretable Multi-Head Attention (long-range)</text>
+  <text x="535" y="590" font-size="10" fill="#1565C0">■</text><text x="550" y="590" font-size="10" fill="#555">LSTM Encoder-Decoder (local processing)</text>
+  <text x="535" y="608" font-size="10" fill="#2E7D32">■</text><text x="550" y="608" font-size="10" fill="#555">Static Enrichment (inject static context)</text>
+  <text x="535" y="626" font-size="10" fill="#6A1B9A">■</text><text x="550" y="626" font-size="10" fill="#555">GRN + Feed-Forward (nonlinear processing)</text>
+  <text x="535" y="644" font-size="10" fill="#F57F17">■</text><text x="550" y="644" font-size="10" fill="#555">Gating / Skip connections (adaptive depth)</text>
+  <text x="535" y="662" font-size="10" fill="#00695C">■</text><text x="550" y="662" font-size="10" fill="#555">Variable Selection + Static Encoders</text>
+</svg>

--- a/ml-guides/nam/images/ch3-variable-selection.svg
+++ b/ml-guides/nam/images/ch3-variable-selection.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 750 420" font-family="Arial, sans-serif">
+  <defs>
+    <marker id="a" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#555"/>
+    </marker>
+  </defs>
+
+  <text x="375" y="25" text-anchor="middle" font-size="16" font-weight="bold" fill="#222">Variable Selection Network (TFT §4.2, Eqs 6-8)</text>
+
+  <!-- Input variables at bottom -->
+  <rect x="50" y="350" width="80" height="30" rx="4" fill="#E3F2FD" stroke="#1565C0" stroke-width="1.2"/>
+  <text x="90" y="370" text-anchor="middle" font-size="11" fill="#1565C0" font-weight="bold">ξ⁽¹⁾_t</text>
+
+  <rect x="170" y="350" width="80" height="30" rx="4" fill="#E3F2FD" stroke="#1565C0" stroke-width="1.2"/>
+  <text x="210" y="370" text-anchor="middle" font-size="11" fill="#1565C0" font-weight="bold">ξ⁽²⁾_t</text>
+
+  <text x="310" y="370" text-anchor="middle" font-size="16" fill="#888">⋯</text>
+
+  <rect x="360" y="350" width="80" height="30" rx="4" fill="#E3F2FD" stroke="#1565C0" stroke-width="1.2"/>
+  <text x="400" y="370" text-anchor="middle" font-size="11" fill="#1565C0" font-weight="bold">ξ⁽ᵐ⁾_t</text>
+
+  <text x="225" y="405" text-anchor="middle" font-size="10" fill="#888">Each ξ⁽ʲ⁾ ∈ ℝ^{d_model} (embedded via linear/entity embedding)</text>
+
+  <!-- Per-variable GRNs -->
+  <rect x="55" y="280" width="70" height="35" rx="4" fill="#FFF3E0" stroke="#E65100" stroke-width="1.2"/>
+  <text x="90" y="302" text-anchor="middle" font-size="10" fill="#E65100" font-weight="bold">GRN_1</text>
+  <line x1="90" y1="350" x2="90" y2="317" stroke="#555" stroke-width="1.2" marker-end="url(#a)"/>
+
+  <rect x="175" y="280" width="70" height="35" rx="4" fill="#FFF3E0" stroke="#E65100" stroke-width="1.2"/>
+  <text x="210" y="302" text-anchor="middle" font-size="10" fill="#E65100" font-weight="bold">GRN_2</text>
+  <line x1="210" y1="350" x2="210" y2="317" stroke="#555" stroke-width="1.2" marker-end="url(#a)"/>
+
+  <text x="310" y="302" text-anchor="middle" font-size="16" fill="#888">⋯</text>
+
+  <rect x="365" y="280" width="70" height="35" rx="4" fill="#FFF3E0" stroke="#E65100" stroke-width="1.2"/>
+  <text x="400" y="302" text-anchor="middle" font-size="10" fill="#E65100" font-weight="bold">GRN_m</text>
+  <line x1="400" y1="350" x2="400" y2="317" stroke="#555" stroke-width="1.2" marker-end="url(#a)"/>
+
+  <text x="90" y="272" text-anchor="middle" font-size="9" fill="#E65100">ξ̃⁽¹⁾ [Eq 7]</text>
+  <text x="210" y="272" text-anchor="middle" font-size="9" fill="#E65100">ξ̃⁽²⁾</text>
+  <text x="400" y="272" text-anchor="middle" font-size="9" fill="#E65100">ξ̃⁽ᵐ⁾</text>
+
+  <!-- Flatten + GRN + Softmax path (right side) -->
+  <rect x="530" y="280" width="90" height="30" rx="4" fill="#E8F5E9" stroke="#2E7D32" stroke-width="1.2"/>
+  <text x="575" y="300" text-anchor="middle" font-size="10" fill="#2E7D32" font-weight="bold">Flatten Ξ_t</text>
+
+  <!-- Arrows from inputs to flatten -->
+  <line x1="132" y1="365" x2="528" y2="295" stroke="#AAA" stroke-width="0.8" stroke-dasharray="3,3"/>
+  <line x1="252" y1="365" x2="528" y2="295" stroke="#AAA" stroke-width="0.8" stroke-dasharray="3,3"/>
+  <line x1="442" y1="365" x2="528" y2="295" stroke="#AAA" stroke-width="0.8" stroke-dasharray="3,3"/>
+
+  <rect x="530" y="225" width="90" height="30" rx="4" fill="#E8F5E9" stroke="#2E7D32" stroke-width="1.2"/>
+  <text x="575" y="245" text-anchor="middle" font-size="10" fill="#2E7D32" font-weight="bold">GRN(Ξ, c_s)</text>
+  <line x1="575" y1="280" x2="575" y2="257" stroke="#555" stroke-width="1.2" marker-end="url(#a)"/>
+
+  <!-- c_s context -->
+  <rect x="660" y="225" width="70" height="30" rx="4" fill="#E0F7FA" stroke="#00695C" stroke-width="1.2"/>
+  <text x="695" y="245" text-anchor="middle" font-size="10" fill="#00695C" font-weight="bold">c_s</text>
+  <line x1="658" y1="240" x2="622" y2="240" stroke="#00695C" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#a)"/>
+
+  <rect x="530" y="170" width="90" height="30" rx="4" fill="#FCE4EC" stroke="#C62828" stroke-width="1.5"/>
+  <text x="575" y="190" text-anchor="middle" font-size="11" fill="#C62828" font-weight="bold">Softmax</text>
+  <line x1="575" y1="225" x2="575" y2="202" stroke="#555" stroke-width="1.2" marker-end="url(#a)"/>
+
+  <text x="575" y="160" text-anchor="middle" font-size="10" fill="#C62828">v = [v⁽¹⁾, v⁽²⁾, …, v⁽ᵐ⁾]  [Eq 6]</text>
+
+  <!-- Weighted sum node -->
+  <circle cx="245" cy="180" r="25" fill="#F3E5F5" stroke="#6A1B9A" stroke-width="2"/>
+  <text x="245" y="175" text-anchor="middle" font-size="10" fill="#6A1B9A" font-weight="bold">Σ v⁽ʲ⁾</text>
+  <text x="245" y="192" text-anchor="middle" font-size="10" fill="#6A1B9A" font-weight="bold">· ξ̃⁽ʲ⁾</text>
+
+  <!-- Arrows from GRN outputs to weighted sum -->
+  <line x1="90" y1="280" x2="225" y2="200" stroke="#555" stroke-width="1.2" marker-end="url(#a)"/>
+  <line x1="210" y1="280" x2="240" y2="207" stroke="#555" stroke-width="1.2" marker-end="url(#a)"/>
+  <line x1="400" y1="280" x2="265" y2="200" stroke="#555" stroke-width="1.2" marker-end="url(#a)"/>
+
+  <!-- Arrow from softmax weights to weighted sum -->
+  <line x1="528" y1="180" x2="272" y2="180" stroke="#C62828" stroke-width="1.5" marker-end="url(#a)"/>
+
+  <!-- Output -->
+  <rect x="200" y="90" width="90" height="35" rx="5" fill="#EDE7F6" stroke="#4527A0" stroke-width="1.5"/>
+  <text x="245" y="112" text-anchor="middle" font-size="12" fill="#4527A0" font-weight="bold">ξ̃_t [Eq 8]</text>
+  <line x1="245" y1="155" x2="245" y2="127" stroke="#555" stroke-width="1.5" marker-end="url(#a)"/>
+
+  <text x="245" y="75" text-anchor="middle" font-size="10" fill="#555">→ to LSTM Encoder/Decoder</text>
+
+  <!-- Annotation -->
+  <text x="660" y="330" font-size="9" fill="#888">Weights shared</text>
+  <text x="660" y="342" font-size="9" fill="#888">across time steps</text>
+</svg>

--- a/ml-guides/nam/neural-additive-models.md
+++ b/ml-guides/nam/neural-additive-models.md
@@ -1,0 +1,465 @@
+# Neural Additive Models
+
+Reference notes on the additive-model family: classical GAMs, Neural Additive Models (NAMs), and Temporal Fusion Transformers (TFT). Aimed at someone with a deep-learning background who needs interpretable models for tabular and industrial time-series data, and wants the mechanisms and the maths in one place rather than three papers.
+
+## Sources
+
+- Hastie, Tibshirani, Friedman. *The Elements of Statistical Learning*, 2nd edition. Chapter 9.1, "Generalized Additive Models" — the canonical textbook treatment, including the backfitting algorithm.
+- Agarwal, Melnick, Frosst, Zhang, Lengerich, Caruana, Hinton. "Neural Additive Models: Interpretable Machine Learning with Neural Nets." NeurIPS 2021, arXiv:2004.13912v2.
+- Lim, Arık, Loeff, Pfister. "Temporal Fusion Transformers for Interpretable Multi-horizon Time Series Forecasting." arXiv:1912.09363v3.
+
+The lineage runs in that order: GAMs define the additive form and fit it with smoothers, NAMs replace each smoother with a small neural network, and TFT abandons additivity but keeps the interpretability motivation for temporal data.
+
+## Additive models
+
+### The additive form
+
+A regression GAM predicts:
+
+$$\mathbb{E}[Y \mid X_1,\ldots,X_p] = \alpha + f_1(X_1) + f_2(X_2) + \cdots + f_p(X_p)$$
+
+Each \(f_j\) is an *unspecified smooth function* of a single feature. No parametric form is assumed; the data decides the shape. The intercept \(\alpha\) captures the overall mean.
+
+Two things follow from the additivity. First, the model is interpretable: you can plot each \(f_j\) to see how feature \(j\) affects the prediction, exactly as you would read the coefficients of a linear model, and the plots are an *exact* decomposition of the prediction rather than an approximation to it. Second, you avoid the curse of dimensionality, because each \(f_j\) is a 1D curve rather than a surface in \(p\) dimensions. The cost is that the model cannot represent interactions between features.
+
+A linear model assumes \(f_j(X_j) = \beta_j X_j\), which misses nonlinear effects. A GAM keeps the additive structure and drops the linearity. That is the whole trade of the family. In a CNN, each filter responds to a specific pattern but all filters interact through later layers; in a GAM each \(f_j\) responds to one input dimension and they *never* interact, they are purely summed.
+
+> **Caution: "GAMs can model interactions" is misleading.** A standard GAM in the form above is strictly additive. You can manually add 2D smooth terms \(g(X_j, X_k)\), and GA²Ms (pairwise interactions) are a later extension, but interaction terms must be specified by the modeler and dramatically increase complexity. When the NAM paper says "NAMs are GAMs," it means the first-order additive form, not the interaction-augmented one.
+
+### The link function
+
+The generalized form is:
+
+$$g(\mu(X)) = \alpha + f_1(X_1) + \cdots + f_p(X_p)$$
+
+where \(g\) is a monotone link function connecting the additive predictor to \(\mathbb{E}[Y]\). For Gaussian responses \(g = \mathrm{id}\); for binary classification \(g = \mathrm{logit}\), \(g(\mu) = \log(\mu/(1-\mu))\); for count data \(g = \log\).
+
+The link is the same idea as the final activation in a neural net. The logit is the inverse sigmoid, so the additive predictor lives in log-odds space and the sigmoid converts it to probability. Where a standard classifier does `logits = Wx + b; p = sigmoid(logits)`, a GAM does the same with \(\alpha + \sum_j f_j(x_j)\) as the logits. If you are comfortable with logistic regression you already understand the logit link; the only new idea is that \(\beta_j X_j\) is replaced by \(f_j(X_j)\).
+
+### Semiparametric and structured variants
+
+The GAM framework is broader than "one smooth per scalar feature". Standard extensions include semiparametric models (some terms linear, some smooth), models where the shape function for one variable depends on the level of a categorical variable, and models with 2D smooth terms. The classical additive time-series decomposition \(Y_t = S_t + T_t + \varepsilon_t\) (seasonal plus trend plus noise) is also a GAM. The binding constraint is that each term is a function of a *small* number of inputs, not that each term takes exactly one.
+
+### Smoothers, penalties, and degrees of freedom
+
+A **smoother** (or scatterplot smoother) is a function-fitting method that takes noisy \((x,y)\) pairs and returns a smooth curve \(\hat{y} = S(x)\). Cubic smoothing splines are the default. Think of it as a 1D curve-fitter trading fidelity to the data against roughness, or as a Gaussian blur on a signal except that it is *learned* from data rather than fixed.
+
+The fitting objective is a penalized residual sum of squares:
+
+$$\mathrm{PRSS}(\alpha, f_1,\ldots,f_p) = \sum_{i=1}^N \Bigl(y_i - \alpha - \sum_j f_j(x_{ij})\Bigr)^2 + \sum_j \lambda_j \int (f_j''(t))^2 \, dt$$
+
+The first term is squared error. The second penalizes the integrated squared second derivative of each \(f_j\), i.e. how much it curves. Large \(\lambda_j\) gives smoother curves; \(\lambda_j = 0\) gives interpolation. This is \(L^2\) regularization on curvature rather than on weights: weight decay penalizes \(\lVert w \rVert^2\), this penalizes \(\lVert f_j'' \rVert_2^2\). The minimizer is an *additive cubic spline model*, each \(f_j\) a natural cubic spline with knots at the observed data points.
+
+Smoothness is usually specified through **degrees of freedom** rather than through \(\lambda\) directly, because df is easier to reason about. Each smoother \(S_j\), evaluated at the training points, is an \(N \times N\) matrix, and the effective degrees of freedom of term \(j\) are \(\mathrm{df}_j = \operatorname{tr}(S_j) - 1\). \(\mathrm{df} = 1\) gives a straight line, \(\mathrm{df} = 4\) a moderately flexible curve. It is the effective number of parameters the smoother is using, analogous to the number of active filters in a conv layer.
+
+> **Caution: the smoother matrix is not a weight matrix.** \(S_j\) maps the response vector \(\mathbf{y}\) to the fitted values \(\hat{y}^{(j)}\) for predictor \(j\). In a linear model, \(S = X(X^\top X)^{-1}X^\top\) is the hat matrix; for a smoothing spline, \(S\) is a banded matrix whose bandwidth depends on \(\lambda\). The key difference from a neural-net weight matrix is that \(S\) is *not* learned by gradient descent, it is determined by the data and the smoothing parameter.
+
+> **Caution: low df does not mean a bad model.** Low \(\mathrm{df}\) means the curve is simple, close to linear. If the true relationship is linear, \(\mathrm{df} \approx 1\) is optimal. Choosing df is choosing model capacity: too low underfits, too high overfits.
+
+### Identifiability and mean-centering
+
+Because the model is a sum of functions plus an intercept, you can shift any \(f_j\) by a constant and compensate in \(\alpha\), so the decomposition is not unique. The convention is to set \(\hat{\alpha} = \frac{1}{N}\sum_i y_i\) and require each \(f_j\) to have mean zero over the data, \(\frac{1}{N}\sum_i f_j(x_{ij}) = 0\).
+
+This is a bookkeeping fix, but it is the reason each \(f_j\) is interpretable in isolation, and it carries directly into NAMs for exactly the same reason.
+
+### Backfitting
+
+Backfitting is the computational heart of classical GAMs:
+
+1. Initialize \(\hat{\alpha} = \frac{1}{N}\sum_i y_i\), all \(\hat{f}_j = 0\).
+2. Cycle through \(j = 1,\ldots,p\) repeatedly:
+   - Compute partial residuals \(r_i = y_i - \hat{\alpha} - \sum_{k \neq j} \hat{f}_k(x_{ik})\)
+   - Fit smoother \(S_j\) to \(\{(x_{ij}, r_i)\}\) to get a new \(\hat{f}_j\)
+   - Re-center: \(\hat{f}_j \leftarrow \hat{f}_j - \frac{1}{N}\sum_i \hat{f}_j(x_{ij})\)
+3. Repeat until convergence.
+
+This is Gauss-Seidel coordinate descent in function space. At each step you ask: holding every other feature's contribution fixed, what is the best 1D curve for feature \(j\)? The partial residuals are exactly "the target minus everything else's contribution", so they isolate what feature \(j\) still has to explain. The re-centering step is theoretically unnecessary (the smoother of a mean-zero response should have mean zero) but practically useful, because floating-point drift accumulates.
+
+The neural-net picture: imagine \(p\) separate 1D networks, one per feature. Backfitting freezes all of them except network \(j\), trains network \(j\) on the residuals, then moves to \(j+1\), cycling until convergence.
+
+> **Caution: backfitting is not neural-net training.** Backfitting is coordinate descent, updating one function at a time with the others frozen. SGD updates all parameters simultaneously. NAMs take the SGD route, which is why they exploit GPU parallelism and do not need backfitting's cycling convergence arguments.
+
+### Additive logistic regression
+
+With a logit link the model is:
+
+$$\log\frac{p}{1-p} = \alpha + \sum_j f_j(X_j)$$
+
+Fitting needs an outer IRLS (iteratively reweighted least squares) loop, the standard algorithm for generalized linear models, wrapped around the backfitting inner loop. This combination is the *local scoring* algorithm. Each outer iteration constructs:
+
+- a *working response* \(z_i = \hat{\eta}_i + \dfrac{y_i - \hat{p}_i}{\hat{p}_i(1 - \hat{p}_i)}\)
+- *weights* \(w_i = \hat{p}_i(1 - \hat{p}_i)\)
+
+and then runs *weighted* backfitting on \((z_i, w_i)\), iterating to convergence.
+
+The working response is a linearization of the log-likelihood at the current estimates: each outer iteration converts the classification problem into a weighted regression problem that backfitting can solve, with weights reflecting the variance of the Bernoulli response at the current predicted probability. If you have implemented Newton's method for logistic regression, the working response and weights are the same objects; IRLS is Newton's method for GLMs in disguise.
+
+The thing worth carrying forward is the shape of the computation, not the algebra: classical GAMs for classification need a nested iterative procedure (outer IRLS, inner backfitting). NAMs collapse both into a single gradient-descent loop on the cross-entropy loss, with no working responses at all.
+
+**The spam example.** ESL fits the additive logistic model to the UCI spam dataset (57 predictors, binary response, df = 4 per predictor). Test error is 5.5% versus 7.6% for linear logistic regression. The accompanying table decomposes each predictor's effect into linear and nonlinear components with p-values for nonlinearity, and the shape-function plots show the fitted curves for the significant predictors.
+
+The instructive detail in those plots: many predictors show a sharp discontinuity at zero. The probability of spam changes dramatically when a word is present versus absent, but barely changes as frequency increases further. That "jumpy" shape is precisely the kind of function standard ReLU networks struggle with, and it is the motivation for NAM's ExU units.
+
+### What additivity gets you, and what it costs
+
+Strengths: a flexible extension of linear models that retains interpretability, with the modeling and inference tooling of linear models (standard errors, p-values) carrying over.
+
+Limitations: backfitting fits *all* predictors, so there is no built-in variable selection, and the method is not designed for high-dimensional settings. BRUTO and lasso-type penalties (SpAM, COSSO) address this. For large problems boosting is more effective, and the Explainable Boosting Machine (EBM) that NAMs benchmark against is exactly that: a boosted-tree GAM. The absence of built-in feature selection is also what motivates the variable selection mechanisms in TFT.
+
+## Neural additive models
+
+### From smoothers to feature nets
+
+A NAM is a GAM in which each shape function is a small neural network. The prediction is:
+
+$$g(\mathbb{E}[y]) = \beta + f_1(x_1) + f_2(x_2) + \cdots + f_K(x_K)$$
+
+which is the classical GAM equation with each \(f_i\) parameterized by a network — a **feature net** (also feature network, or subnet) that takes only one input dimension. The nets are trained *jointly* by backpropagation, not cycled through as in backfitting.
+
+![Diagram: NAM architecture](images/ch2-nam-architecture.svg)
+
+*Diagram description*: \(K\) input features \(x_1,\ldots,x_K\) on the left. Each feeds into its own feature network (small DNN). Each feature net outputs a scalar \(f_i(x_i)\). These scalars are summed, a bias \(\beta\) is added, and the result passes through a link function (\(\sigma\) for classification, identity for regression) to produce the prediction.
+
+The architecture is that simple: one small DNN per feature, outputs summed, optional link function. The paper uses two feature-net architectures: a 3-layer DNN with 64/64/32 units and ReLU, or a single hidden layer with 1024 ExU units and ReLU-1.
+
+The motivation for the swap is not accuracy. The GAM framework is powerful but tied to statistical fitting methods (splines, boosted trees) that are awkward to extend to multi-task learning, GPU training, or composition with other deep-learning components. Replacing smoothers with networks keeps the interpretability and buys differentiability and composability.
+
+> **Caution: a NAM is not one network.** It is \(K\) *separate* networks, one per feature, trained jointly. This is not a single network with \(K\) outputs, each feature net has its own weights and sees only one input dimension.
+
+NAMs are **glass-box** models: the computation is transparent, and the shape-function plots *are* the computation rather than a post-hoc approximation to it. This is the sharp distinction the paper draws against LIME and SHAP, which try to explain black boxes and are often unfaithful to what the model actually computes. Grad-CAM for a CNN is post-hoc, it highlights pixels but does not tell you the computation. A NAM shape plot is the decision function itself, written out as a plottable curve. In high-stakes domains the argument is that you want the model to *be* interpretable, not to have an explanation bolted on afterwards.
+
+### The jagged-function problem
+
+The paper constructs a toy binary classification dataset whose log-odds vary rapidly with the input. A standard ReLU network with 1024 hidden units in a single layer, trained with mini-batch SGD, fails to fit it and learns a smooth approximation instead; a 3-layer DNN fails too. The paper attributes this to the spectral bias of ReLU networks toward smooth functions.
+
+The toy dataset tests *overfitting ability*, not generalization. The point is that even with 1024 hidden units the network cannot reproduce the training signal, which is a problem in the optimization landscape rather than in the architecture's expressivity. The closest familiar analogue is NeRFs struggling with high-frequency texture detail until positional encoding or Fourier features are added: a smoothness bias that has to be overcome architecturally.
+
+This matters because real shape functions do have sharp discontinuities, whether the spam word-presence jumps above or the PFRatio jump in the MIMIC-II clinical data.
+
+### ExU units
+
+An ExU (exp-centered) hidden unit replaces the standard \(h(x) = f(w \cdot x + b)\) with:
+
+$$h(x) = f\bigl(e^w (x - b)\bigr)$$
+
+where \(w\) and \(b\) are scalars and \(f\) is typically ReLU-1.
+
+The slope of the affine factor is \(e^w\). Because the exponential grows fast, \(w = 3\) already gives a slope of about 20 and \(w = 5\) about 148, so the network can produce very steep transitions from small weight values, which gradient descent finds much easier. Standard ReLU units under Kaiming or Xavier initialization start with moderate slopes and struggle to reach the extreme slopes a sharp jump needs.
+
+> **Caution: ExU units do not add expressivity.** The paper is explicit: "ExU units do not improve the expressivity of neural nets, however they do improve their learnability for fitting jumpy functions." A wide enough ReLU network can represent the same functions; ExU just makes it easier for SGD to find them.
+
+> **Caution: the ExU initialization is load-bearing, not incidental.** ExU units with standard initialization also struggle. Initializing \(w \sim \mathcal N(x, 0.5)\) with \(x \in [3, 4]\) means the network *starts* as a jagged random function, which the authors find crucial for fitting jumpy targets.
+
+**ReLU-\(n\)** is the companion activation, \(\mathrm{ReLU}\text{-}n = \min(\max(0, x), n)\). Capping the activation at \(n\) keeps each ExU unit active over a limited input range, so it can model a sharp jump at a specific point without disturbing the function elsewhere. Mechanically this is ReLU6 from MobileNets; the motivation differs (localizing function support rather than quantization behavior).
+
+### Regularization
+
+ExU units are *designed* to learn jagged functions, which makes them highly prone to overfitting noise. NAMs therefore apply four regularizers simultaneously:
+
+1. **Dropout** within each feature net, which regularizes ExU units and smooths the learned function.
+2. **Weight decay**, an \(L^2\) penalty on each feature net's weights.
+3. **Output penalty**, an \(L^2\) penalty on each feature net's *output*: \(\lambda_1 \cdot \frac{1}{K} \sum_{k} \sum_{x} \bigl(f_k(x_k)\bigr)^2\). This keeps each shape function near zero unless the data provides strong evidence otherwise.
+4. **Feature dropout**, dropping entire feature nets during training, which discourages correlated features from splitting a single effect across several shape functions.
+
+The full training loss is:
+
+$$\mathcal{L}(\theta) = \mathbb{E}\bigl[\ell(x,y;\theta) + \lambda_1 \eta(x;\theta)\bigr] + \lambda_2 \gamma(\theta)$$
+
+with \(\ell\) the task loss (cross-entropy or MSE), \(\eta\) the output penalty, and \(\gamma\) weight decay. Feature dropout and unit dropout carry their own coefficients \(\lambda_3\) and \(\lambda_4\).
+
+The regularization interacts with ensembling in a specific way worth remembering: individual sub-networks under dropout produce very jagged curves, but the ensemble average is smooth with *localized* jumps, which is exactly the desired shape.
+
+> **Caution: NAM dropout is two mechanisms, not one.** Standard dropout inside each feature net (\(\lambda_4\)) and feature dropout over whole feature nets (\(\lambda_3\)) are separate. Feature dropout is NAM-specific and exists to stop correlated features from splitting effects.
+
+### Intelligibility and modularity
+
+Each shape function is centered so its average score over the training set is zero, and a single bias \(\beta\) is set so the mean prediction matches the observed baseline. This is the same identifiability convention as classical GAMs, and it buys two properties:
+
+- Positive \(f_j(x_j)\) means feature \(j\) pushes the prediction above baseline at that value; negative means below.
+- Any shape function can be zeroed out without biasing the remaining predictions.
+
+The second property is what makes the bias-detection use case work: in the COMPAS recidivism experiment, the race feature's shape function can simply be removed from a trained model.
+
+### Reading shape-function plots
+
+The visualization protocol is how you actually use a NAM, and it is worth following exactly. Plot \(f_k(x_k)\) against \(x_k\) for an *ensemble* of NAMs using semi-transparent lines: where ensemble members agree you get a dark, thick line, and disagreement shows up as spread. Overlay data density as bars on the same axes. Sparse regions flag where the learned shape function is unreliable, which is the most common way these plots get over-read.
+
+In industrial settings these plots are the artifact you put in front of process engineers to validate the model, so the density overlay matters as much as the curve.
+
+### Accuracy against EBMs and black boxes
+
+From the paper's Table 1:
+
+| Model | MIMIC-II (AUC↑) | CA Housing (RMSE↓) |
+|---|---|---|
+| Log./Linear Reg. | 0.791 | 0.728 |
+| NAMs | 0.830 | 0.562 |
+| EBMs | 0.835 | 0.557 |
+| XGBoost | 0.844 | 0.532 |
+| DNNs | 0.832 | 0.492 |
+
+NAMs track EBMs closely across all datasets. The remaining gap to full-complexity models (XGBoost, DNNs) is the price of interpretability, and it is paid entirely in missing feature interactions.
+
+> **Caution: NAMs are not "better than EBMs".** EBMs are slightly ahead on several datasets, including both shown above. NAM's advantage is not raw accuracy but flexibility: differentiability, GPU training, and composability.
+
+### Composability: parameter generation and multitask NAMs
+
+The two capabilities that tree-based GAMs cannot match both follow from differentiability.
+
+**Intelligible parameter generation.** A NAM can generate the parameters of another model. In the paper's COVID-19 example, a NAM maps patient features to estimated treatment benefits, which are then used as weights in a mortality-risk model, and the whole pipeline trains end to end by backpropagation. The resulting shape functions read directly: anti-coagulant benefit decreases with Neutrophil/Lymphocyte Ratio while glucocorticoid benefit increases. This is impossible with boosted trees because trees are not differentiable. The general point is that a NAM can be a *component* in a larger differentiable pipeline, which matters when a NAM feeds a downstream controller or optimizer.
+
+**Multitask NAMs.** Train multiple subnets per feature and learn task-specific weighted sums over them: each feature \(i\) has \(S\) subnets, and each task \(t\) gets weights \(w_{i,s,t}\) over those subnets. On the paper's synthetic experiment this gives 34% lower MSE than single-task NAMs. On COMPAS it surfaces different racial-bias patterns for men and women that single-task models cannot separate. A multitask EBM would require changes to both the backfitting procedure and the tree-splitting criterion; with NAMs you add output heads.
+
+### Related models worth knowing
+
+GANNs (Potts, 1999) were an earlier neural-net GAM, but predated deep learning: 1 to 5 hidden units per feature, human-in-the-loop evaluation, no scalability. NAMs benefit from large hidden layers, ExU units, ensembling, and GPU training.
+
+Current neighbours: **EBMs** (InterpretML) are the tree-based GAM competitor and the accuracy target. **NodeGAM** uses differentiable oblivious trees instead of neural nets for each shape function. **NBM** (Neural Basis Models) learn a shared basis of shape functions rather than independent feature nets. Directions the NAM paper leaves open: higher-order interactions (GA²M-style pairwise terms with neural nets), better activation functions, and extension beyond tabular data — CNN-LSTM NAM variants already exist for genomics.
+
+## Additive models on time series
+
+### Framing time series as tabular rows
+
+Neither a GAM nor a NAM consumes a time series natively; both expect a tabular row \((x_1,\ldots,x_p) \to y\), so the temporal structure has to be flattened into features. Each row is one prediction point ("predict quality at time \(t\)") and the columns are:
+
+- **Lag features**: \(x_t, x_{t-1},\ldots,x_{t-k}\) as separate columns, each getting its own \(f_j\).
+- **Rolling-window summaries**: mean, std, min, max over the last \(k\) steps.
+- **Calendar features**: hour-of-day, day-of-week, month, shift number.
+- **Static features**: reactor ID, catalyst batch.
+
+For an ethylene purity model that means columns like TI-101\(_{t-1}\), TI-101\(_{t-2}\), FI-201\(_{t-1}\), mean(TI-101, \(t{-}6{:}t\)), std(FI-201, \(t{-}12{:}t\)), hour_of_day\(_t\), catalyst_batch. Every one of these becomes a separate feature with its own shape function and its own plot, so you get an answer to "how does TI-101 two steps ago affect purity?" directly, which is a question a process engineer can check against domain knowledge.
+
+### Splitting and leakage
+
+Random train/test splits are invalid here: future information leaks into training. Split temporally, train on \([0, T_1]\), validate on \((T_1, T_2]\), test on \((T_2, T_3]\), and check that the lag window used for training rows does not reach into the validation period.
+
+The specific trap with lag features is constructing them and *then* shuffling, which produces rows whose "past" features come from the validation period. Build the full feature matrix first, then split on time.
+
+### Where additive models hold up
+
+They work well when each feature has an approximately independent, static effect on the target: "reactor temperature above 350 °C always increases the risk of coking, regardless of pressure." The additive structure makes that kind of relationship transparent. Soft-sensor calibration is the natural fit, where the mapping from lab-sampled quality variables to continuous sensor features is reasonably stable.
+
+The transparency is also more useful than a SHAP summary plot, because the shape function is the *exact* functional form the model uses. If the curve for "reactor pressure at lag 3" is non-monotone, an engineer can confirm or reject that pattern outright.
+
+### Where they break
+
+- **No temporal dynamics.** The effect of a feature cannot depend on what preceded it. There is also no notion of temporal ordering at all: lag-1 and lag-10 are just two unrelated columns.
+- **No interactions.** This hurts more on time series than on static tabular data, because temporal events *are* interactions. "Rising pressure combined with falling temperature" is a different event from either alone, and an additive model cannot see it.
+- **No non-stationarity.** The learned relationship is fixed; drifting process behavior is not represented.
+- **Feature blow-up.** The column count grows as lags × tags, which makes wide models unwieldy and, since classical GAMs have no variable selection, expensive.
+
+For these you need memory (LSTMs, Transformers) or explicit interaction terms (GA²M, gradient-boosted trees, full DNNs).
+
+### Worked example: ethylene splitter soft sensor
+
+An olefins plant ethylene splitter column. The target is ethylene purity, a lab-measured quality variable sampled every 4 hours. Features: column top temperature (TI-101), reflux flow (FI-201), reboiler duty (QI-301), a feed composition proxy (AI-401), and ambient temperature.
+
+A GAM soft sensor learns one shape function per tag: \(f_{\mathrm{TI\text{-}101}}(\mathrm{temp})\), \(f_{\mathrm{FI\text{-}201}}(\mathrm{flow})\), and so on. The plot of \(f_{\mathrm{TI\text{-}101}}\) might show purity dropping sharply once top temperature exceeds 35 °C, which is directly actionable for operators. What it cannot show is that the *rate of change* of TI-101 matters, or that the effect of reflux flow depends on feed composition.
+
+### Worked example: crude unit kerosene endpoint
+
+A refinery crude distillation unit, with a NAM soft sensor for kerosene endpoint temperature, sampled by lab every 8 hours. Features: tray temperatures at multiple lags, overhead reflux flow at multiple lags, feed flow rate, ambient temperature.
+
+The NAM might learn that \(f_{\mathrm{tray\_temp\_lag1}}(x)\) has a steep positive slope above 220 °C, telling operators that the tray temperature two hours ago is a critical predictor of off-spec product. It cannot learn that a *simultaneous* drop in reflux flow and rise in tray temperature is more dangerous than either alone; that interaction is invisible to the model.
+
+Both examples are why the lineage continues: NAMs keep the shape-function transparency and add neural-net fitting, and TFT adds temporal processing and interactions at the cost of the additive decomposition.
+
+### Recognising the pattern in a codebase
+
+The additive paradigm is visible from two artifacts, regardless of what fits the shape functions underneath. One is code that builds the feature matrix by flattening lag and rolling-window features from historian tags into tabular rows. The other is per-feature shape-function plotting utilities used for model explanation. If both are present, you are looking at a GAM pipeline whether the estimator is a spline GAM, an EBM, or a NAM; the plotting utility and the lag-matrix builder are the two places to look first.
+
+## Temporal fusion transformers
+
+TFT is not a GAM. It models interactions, so you cannot isolate a feature's contribution with a shape plot. What it shares with NAMs is the interpretability *motivation*, and it offers analogous artifacts: variable importance scores instead of shape functions, and attention patterns showing *when* matters. Use NAMs when you need per-feature transparency on tabular data, TFT when you need multi-horizon forecasting over heterogeneous inputs.
+
+> **Caution: TFT is not additive.** Attention and GRNs see all features jointly. TFT's interpretability comes from variable selection weights and attention patterns, not from additive decomposition.
+
+### The input taxonomy
+
+This is the single most important concept in the paper; every architectural decision follows from it.
+
+- **Static covariates (\(\mathbf{s}\))**: time-invariant metadata, e.g. reactor ID, catalyst type, sensor location. Never change across time steps.
+- **Known future inputs (\(\mathbf{x}\))**: time-varying features whose future values *are* known at forecast time, e.g. day-of-week, scheduled maintenance windows, holiday calendars, planned production rates.
+- **Observed past inputs (\(\mathbf{z}\))**: time-varying features available only up to the current time, e.g. sensor readings, market prices, weather measurements. History visible, future not.
+- **Target (\(y\))**: the series being predicted. Past values observed, future values forecast.
+
+An **entity** is a distinct time series within the dataset (one store, one patient, one stock index), each with its own static covariates and temporal trajectory.
+
+Most prior methods either assume all inputs are known into the future (as autoregressive models like DeepAR and DSSM require) or ignore static covariates by concatenating them onto temporal features. TFT routes each input type through a path built for it.
+
+**Multi-horizon forecasting** means predicting the target at multiple future steps simultaneously (\(t{+}1, t{+}2, \ldots, t{+}24\)) rather than only the next value. TFT is a *direct* method: it generates all horizons at once via sequence-to-sequence, rather than iterating one-step predictions back into the input, which avoids error accumulation and handles the input types naturally.
+
+### The forecast function
+
+$$\hat{y}(q, t, \tau) = f_q\bigl(\tau, y_{t-k:t}, z_{t-k:t}, x_{t-k:t+\tau}, s\bigr)$$
+
+Predict the \(q\)-th quantile of the \(\tau\)-step-ahead forecast given a look-back window of \(k\) past target values, past observed inputs \(z\), known inputs \(x\) across the full past-through-future range, and static covariates \(s\).
+
+The asymmetry is the point: known inputs extend to \(t+\tau\), while observed inputs and past targets stop at \(t\). That is why TFT needs separate processing paths for past and future.
+
+### Architecture overview
+
+![Diagram: TFT architecture overview](images/ch3-tft-architecture.svg)
+
+*Diagram description*: The full TFT data flow from bottom to top: (1) Static metadata, past inputs, and known future inputs enter at the bottom. (2) Variable Selection Networks (one for static, one for past, one for future) select and weight features. (3) Static Covariate Encoders produce \(\mathbf{c}_s, \mathbf{c}_e, \mathbf{c}_c, \mathbf{c}_h\). (4) LSTM Encoder (past) and LSTM Decoder (future) process temporal features, initialized by \(\mathbf{c}_c\) and \(\mathbf{c}_h\). (5) Gated skip connection. (6) Static Enrichment Layer enriches temporal features with \(\mathbf{c}_e\). (7) Interpretable Multi-Head Attention with decoder masking. (8) Gated skip connection. (9) Position-wise Feed-Forward (GRN). (10) Gated skip connection over the entire transformer block. (11) Dense layers produce quantile outputs.
+
+### Gating: GLUs and gated residual networks
+
+A **Gated Linear Unit**, borrowed from language modeling, is:
+
+$$\mathrm{GLU}(\boldsymbol{\gamma}) = \sigma(W_4 \boldsymbol{\gamma} + \mathbf{b}_4) \odot (W_5 \boldsymbol{\gamma} + \mathbf{b}_5)$$
+
+The sigmoid gate controls how much of the linear transformation passes through, which lets the network suppress components it does not need.
+
+The **Gated Residual Network (GRN)** is TFT's fundamental building block. It takes a primary input \(\mathbf{a}\) and an optional context vector \(\mathbf{c}\):
+
+$$\begin{aligned}
+\mathrm{GRN}(\mathbf{a}, \mathbf{c}) &= \mathrm{LayerNorm}\bigl(\mathbf{a} + \mathrm{GLU}(\boldsymbol{\eta}_1)\bigr), \\
+\boldsymbol{\eta}_1 &= W_1 \boldsymbol{\eta}_2 + \mathbf{b}_1, \\
+\boldsymbol{\eta}_2 &= \mathrm{ELU}(W_2 \mathbf{a} + W_3 \mathbf{c} + \mathbf{b}_2).
+\end{aligned}$$
+
+The GLU gate can suppress the entire nonlinear path, passing \(\mathbf{a}\) through unchanged. That is TFT's mechanism for *adaptive depth*: on a dataset that does not need complex nonlinear processing, the gates learn to close and the model simplifies itself.
+
+Structurally this is a gated residual connection, like a highway network or gated ResNet block, with two differences: the gate is a GLU (\(\sigma \odot\) linear) rather than a learned scalar, and the context vector \(\mathbf{c}\) lets static information modulate the gating. GRNs appear throughout TFT, in variable selection, static enrichment, and the position-wise feed-forward layer.
+
+### Variable selection networks
+
+![Diagram: Variable Selection Network](images/ch3-variable-selection.svg)
+
+*Diagram description*: Multiple input variables \(\xi^{(1)}, \xi^{(2)}, \ldots, \xi^{(m)}\) (each already transformed to \(d_{\mathrm{model}}\) dimensions) are flattened into \(\mathbf{\Xi}\) and fed through a GRN with external context \(\mathbf{c}_s\), then a \(\mathrm{Softmax}\) to produce selection weights \(\mathbf{v}\). Separately, each \(\xi^{(j)}\) is processed by its own GRN. The final output is the weighted sum \(\tilde{\boldsymbol{\xi}} = \sum_j v^{(j)} \, \tilde{\boldsymbol{\xi}}^{(j)}\).
+
+Each input variable is first embedded into a \(d_{\mathrm{model}}\)-dimensional vector (entity embeddings for categoricals, linear transforms for continuous). The selection weights are a softmax over a GRN that sees all flattened inputs plus the static context vector:
+
+$$\mathbf{v} = \mathrm{Softmax}\bigl(\mathrm{GRN}(\mathbf{\Xi}, \mathbf{c}_s)\bigr)$$
+
+Each variable is also processed by its own GRN, weight-shared across time:
+
+$$\tilde{\boldsymbol{\xi}}^{(j)} = \mathrm{GRN}_j\bigl(\xi^{(j)}\bigr)$$
+
+and the combined representation is the weighted sum:
+
+$$\tilde{\boldsymbol{\xi}} = \sum_j v^{(j)} \, \tilde{\boldsymbol{\xi}}^{(j)}$$
+
+This is an attention-like mechanism over *features*, not time steps. The network learns which features to attend to at each time step, conditioned on all available features and on static metadata, and the weights \(\mathbf{v}\) are directly readable as instance-wise feature importance. Real datasets carry many irrelevant or noisy features; variable selection removes them early, which helps both accuracy and interpretability.
+
+Against NAMs: a NAM gives every feature equal treatment and no learned selection, dedicating a feature net to each one. TFT's weighting is dynamic and input-dependent, which is why it copes gracefully with many noisy features.
+
+> **Caution: variable importance is not a shape function.** A NAM shape function shows the *full functional relationship* between a feature and the output. A TFT selection weight is a scalar per feature per time step: how much the feature is selected, not *how* it is used.
+
+### Static covariate encoders
+
+Static features pass through the static variable selection network to produce a representation \(\zeta\), and four separate GRNs then generate four context vectors:
+
+- **\(\mathbf{c}_s\)**: conditions temporal variable selection, telling the selector which features matter for this entity.
+- **\(\mathbf{c}_c, \mathbf{c}_h\)**: initialize the LSTM cell and hidden states, seeding local temporal processing with entity-specific context.
+- **\(\mathbf{c}_e\)**: enriches temporal features in the static enrichment layer.
+
+Other methods either ignore static covariates or crudely concatenate them onto temporal features at every step. TFT routes static information to the specific places it is needed.
+
+### Interpretable multi-head attention
+
+Standard multi-head attention uses different Q, K, *and* V projections per head and concatenates the head outputs, which means attention weights from different heads are not comparable: they attend to different value subspaces.
+
+TFT shares the value weights \(W_V\) across all heads and averages the attention outputs:
+
+$$\mathrm{InterpretableMultiHead}(Q, K, V) = \tilde{H} \, W_H, \qquad \tilde{H} = \frac{1}{m_H} \sum_{h=1}^{m_H} \mathrm{Attention}\bigl(Q W_Q^{(h)},\, K W_K^{(h)},\, V W_V\bigr)$$
+
+Because all heads attend to the same value representation, their attention weights can be meaningfully averaged into a single matrix \(\bar{A}(Q, K)\), which can then be analyzed to see which past time steps drive each forecast horizon. The averaged attention matrix is a simple ensemble of per-head patterns applied to one shared value representation.
+
+The trade is explicit: TFT gives up per-head value projections, and some representational capacity with them, to gain analyzable attention.
+
+> **Caution: the heads still differ.** Sharing \(W_V\) does not make the heads identical, they retain separate \(Q\) and \(K\) projections and learn different attention patterns. What they share is the value representation those patterns are applied to.
+
+> **Caution: attention does not show which features matter.** TFT's self-attention operates over *time steps*. It tells you which time positions the model attends to. Feature importance comes from the variable selection networks. Conflating the two is the most common misreading of the architecture.
+
+### The temporal fusion decoder
+
+Four layers process the temporal features.
+
+**Locality enhancement via seq2seq.** An LSTM encoder-decoder processes past \(\tilde{\xi}_{t-k:t}\) and future \(\tilde{\xi}_{t+1:t+\tau_{\max}}\) inputs separately, with static context vectors \(\mathbf{c}_c\) and \(\mathbf{c}_h\) initializing the LSTM states. A gated skip connection adds back the original variable-selected features:
+
+$$\tilde{\varphi}(t, n) = \mathrm{LayerNorm}\bigl(\tilde{\xi}_{t+n} + \mathrm{GLU}(\varphi(t, n))\bigr)$$
+
+The LSTM captures local temporal patterns (short-term dependencies, trends) while attention captures long-range structure, the same two-scale split as local convolutions plus global attention in a vision transformer.
+
+> **Caution: the LSTM is not optional in practice.** Ablating local processing (replacing the LSTM with positional encoding) costs 10 to 28% P90 loss increases on some datasets. Attention alone does not recover the local features.
+
+**Static enrichment.** A GRN enriches each temporal feature with the static context vector, letting static metadata influence how temporal features are processed:
+
+$$\theta(t, n) = \mathrm{GRN}\bigl(\tilde{\varphi}(t, n), \mathbf{c}_e\bigr)$$
+
+**Self-attention with decoder masking.** The interpretable multi-head attention is applied to the static-enriched features, masked so future time steps cannot attend to later ones, with a gated skip connection preserving the pre-attention representation:
+
+$$B(t) = \mathrm{InterpretableMultiHead}\bigl(\Theta(t), \Theta(t), \Theta(t)\bigr)$$
+
+**Position-wise feed-forward and the block-level skip.** A GRN applies nonlinear processing to the attention output, then a gated skip connection spans the *entire* transformer block, from the seq2seq output \(\tilde{\varphi}\) to the final \(\tilde{\psi}\):
+
+$$\tilde{\psi}(t, n) = \mathrm{LayerNorm}\bigl(\tilde{\varphi}(t, n) + \mathrm{GLU}(\psi(t, n))\bigr)$$
+
+That path can bypass static enrichment, attention, and feed-forward together, so a dataset that does not require the attention machinery can fall back to the LSTM's local processing alone.
+
+### Quantile outputs and the pinball loss
+
+One linear head per quantile maps the decoder output to forecasts, generated only for future horizons \(\tau \in \{1, \ldots, \tau_{\max}\}\):
+
+$$\hat{y}(q, t, \tau) = W_q \, \tilde{\psi}(t, \tau) + b_q$$
+
+**Quantile regression** predicts several quantiles (10th, 50th, 90th) instead of a single point estimate, which gives prediction intervals without assuming a distribution. The per-prediction loss is the asymmetric pinball loss:
+
+$$\mathrm{QL}(y, \hat{y}, q) = q \, (y - \hat{y})_+ + (1-q) \, (\hat{y} - y)_+ , \quad (\cdot)_+ = \max(0, \cdot)$$
+
+At \(q = 0.5\) this is the median (half the MAE). At \(q = 0.9\), under-predictions are penalized nine times more heavily than over-predictions.
+
+The training loss sums pinball loss across quantiles, horizons, and samples:
+
+$$\mathcal{L} = \frac{1}{M \, \tau_{\max}} \sum_{y \in \Omega} \sum_{q \in Q} \sum_{\tau=1}^{\tau_{\max}} \mathrm{QL}\bigl(y,\, \hat{y}(q, t-\tau, \tau),\, q\bigr)$$
+
+with \(Q = \{0.1, 0.5, 0.9\}\) in the experiments. Evaluation uses **q-Risk**, the quantile loss normalized by the sum of absolute target values, which makes it comparable across datasets.
+
+> **Caution: quantile regression is not a TFT contribution.** MQRNN and other direct methods use it too. TFT's contribution is the architecture, not the loss.
+
+### What the ablations say
+
+TFT achieves the lowest q-Risk on all four benchmark datasets (Electricity, Traffic, Retail, Volatility), improving 3 to 26% over the next best method, against both direct (Seq2Seq, MQRNN) and iterative (DeepAR, DSSM, ConvTrans) baselines. The gains are largest where static and observed inputs are rich (Retail, Volatility), which is the input-taxonomy argument paying off.
+
+Component by component:
+
+- Local processing (LSTM) and self-attention have the largest impact.
+- Static encoders and variable selection contribute 2.6 to 7% on average.
+- Gating helps most on small or noisy datasets (Volatility: 4.1% P90 increase when ablated).
+- Relative component importance is dataset-specific; nothing dominates everywhere.
+
+### The three interpretability artifacts
+
+**Variable importance.** Aggregate the selection weights \(v^{(j)}\) across the test set and report the 10th, 50th, and 90th percentiles of each variable's importance. On the Retail dataset this identifies item number, store number, and log sales as the most important static, past, and future inputs respectively.
+
+**Persistent temporal patterns.** For one-step-ahead forecasts, the attention weights \(\alpha(t, n, 1)\) show which past steps \(n\) the model attends to, and aggregating across test samples reveals persistent structure: clear daily seasonality on Electricity and Traffic (spikes every 24 hours), weekly seasonality with decaying importance on Retail, near-uniform attention on Volatility (moving-average-like behavior). Traditional lag and seasonality analysis requires the analyst to specify the lag structure up front; here it is learned and then read off.
+
+**Regime identification.** Define a distance between each time step's attention pattern and the average pattern using the Bhattacharyya coefficient. Spikes in that distance mark regime changes, e.g. the 2008 financial crisis in the Volatility dataset. Industrially, regime changes are process upsets, catalyst deactivation, or equipment degradation, so this is an automatic flag for "the model's behavior has stopped looking like it usually does".
+
+### Time-series framing for TFT
+
+Unlike NAMs, TFT consumes time series natively, with no flattening. You provide a look-back window of \(k\) past steps (past targets, observed inputs, known inputs), a forecast window of \(\tau_{\max}\) future steps (known inputs only), and static covariates per entity. The feature-engineering work is mostly *classification* of variables into static, known, and observed; the temporal structure is the architecture's job.
+
+Splits are temporal, with the look-back and forecast windows sliding over the series. One subtlety: because TFT forecasts all entities simultaneously, the validation set has to be separated in time, not by entity.
+
+TFT earns its complexity when inputs are heterogeneous (static metadata plus known schedules plus past-only sensors), there are multiple horizons, and both accuracy and interpretability are required. Variable selection is especially valuable on industrial data where many sensor tags exist but few are relevant. Against that, TFT is complex and data-hungry: small datasets, or datasets with few features, may not benefit from the full machinery (gating mitigates this, but an LSTM or a NAM may simply be the better fit), and it never gives you plottable shape functions.
+
+A TFT deployment is recognisable from four pieces: input configuration that classifies each tag as static, known, or observed; a sliding-window data loader that constructs (entity, look-back, forecast) tuples; variable selection weight plots aggregated over test windows; and attention heatmaps showing which look-back positions matter for each forecast horizon. The tag classification is where the modelling judgement lives, and it is the easiest thing to get wrong: a tag whose future values are *scheduled* rather than *measured* belongs in the known-future group, not the observed-past one.
+
+### Worked example: gas turbine efficiency forecast
+
+A combined-cycle gas turbine power plant. Target: thermal efficiency, forecast 24 hours ahead at hourly resolution.
+
+- **Static**: turbine model, fuel type, site elevation.
+- **Known future**: ambient temperature forecast, scheduled load profile, planned maintenance flags.
+- **Observed past**: exhaust gas temperature, compressor pressure ratio, vibration readings, stack NOx.
+
+TFT would learn variable selection weights showing, for instance, that exhaust temperature (observed past) and scheduled load (known future) dominate. Attention patterns might show daily periodicity, with efficiency tracking the ambient temperature cycle, plus spikes at lag 24 hours ("same time yesterday"). Regime identification could flag periods of turbine degradation where the attention pattern shifts away from its usual shape.
+
+The same problem given to a NAM would require flattening all of those inputs into lag and window features, losing the temporal structure and producing a very wide feature matrix. You would get per-feature shape functions, useful for understanding individual sensor effects, but none of the temporal dynamics the attention layer exposes.
+
+### NAM or TFT
+
+The split is clean in practice. NAMs handle the flat tabular soft-sensor case: predict a single lab quality variable from current and lagged sensor values, and hand the engineer a shape function per tag. TFT handles multi-horizon forecasting: predict the next 24 hours given historical sensor trajectories and scheduled operating conditions, and hand the engineer importance scores plus attention patterns. NAMs tell you *how* a feature is used; TFT tells you *which* features and *which* time steps mattered.

--- a/ml-guides/tabular-data.md
+++ b/ml-guides/tabular-data.md
@@ -1,0 +1,19 @@
+# Concepts
+
+## Tabular Data
+
+### Long vs Wide Format
+
+**Long format** — one row per measurement. Columns are `(tag/id, timestamp, value)`. Every new tag or analyte adds rows, not columns. Sparse data stays compact.
+
+**Wide format** — one row per timestamp. Every tag or analyte is its own column. Good for ML feature tables where you want all signals aligned on the same time index.
+
+### How tables are stored in this project
+
+| Table | Format | Why |
+|---|---|---|
+| `silver.timeseries.events` | Long | One row per tag per minute — 1,492 tags × 2.06B rows |
+| `bronze.lims.measurements` | Long | 35 sampling points × varying analytes; matches historian convention |
+| `features_10min_at_load.parquet` | Wide | ML input — pivoted from silver events; one row per 10-min interval, ~517 columns |
+
+The pivot from long → wide happens in `build_training_dataset.py` at feature engineering time. When joining LIMS into the training parquet, you pivot only the analytes you need from `bronze.lims.measurements` the same way.

--- a/reading-list/edge-ml.md
+++ b/reading-list/edge-ml.md
@@ -1,0 +1,8 @@
+# ML / LLMs on edge devices — external links
+
+Curated reading list for running models on-device: tiny LLMs, on-device agents, and edge runtimes.
+
+## Talks
+
+- [TLMs: Tiny LLMs and Agents on Edge Devices with LiteRT-LM](https://www.youtube.com/watch?v=BKWpYIWvAo4) — Cormac Brick, Google. Tiny language models ("TLMs") and agents running on-device on LiteRT-LM, Google's on-device LLM runtime in the LiteRT / TensorFlow Lite lineage. Start here for the overview.
+- [From 46% to 90%: Fine-Tuning Tiny LLMs for On-Device Agents](https://www.youtube.com/watch?v=-TiET_K-E_g) — Cormac Brick, Google. Fine-tuning small models up to usable agent accuracy for on-device use; the accuracy jump in the title is the headline result.

--- a/reading-list/knowledge-graphs.md
+++ b/reading-list/knowledge-graphs.md
@@ -1,0 +1,14 @@
+# Knowledge graphs — external links
+
+Curated reading list for knowledge graphs and GraphRAG. Unread; working through these.
+
+## Courses
+
+- [Knowledge Graphs for RAG](https://www.deeplearning.ai/courses/knowledge-graphs-rag) — DeepLearning.AI, Andreas Kollegger (Neo4j). 9 lessons, ~2h. Nodes/edges fundamentals, Cypher, adding a vector index to an existing graph, building a KG from SEC 10-K filings, connecting multiple graphs, then LangChain QA over the result. Assumes some LangChain familiarity.
+  - Notes: [kaushikacharya/Knowledge_Graphs_for_RAG](https://github.com/kaushikacharya/Knowledge_Graphs_for_RAG) — third-party per-lesson write-ups (`notes/`, lessons 0-7) plus `code/` assignments. Good for skimming the course content without sitting through the videos.
+
+## GraphRAG walkthroughs
+
+- [Building, Improving, and Deploying Knowledge Graph RAG Systems on Databricks](https://www.databricks.com/blog/building-improving-and-deploying-knowledge-graph-rag-systems-databricks) — Databricks Blog. GraphRAG with Neo4j as the graph store, driven from Databricks: Delta Tables as the source, LLM-generated Cypher for retrieval, HNSW vector indexes, deployment via Agent Bricks Custom Agents. Core argument is combining explicit graph relationships with implicit embedding similarity.
+- [RAG with knowledge graphs (Neo4j)](https://huggingface.co/learn/cookbook/en/rag_with_knowledge_graphs_neo4j) — HuggingFace Cookbook. Runnable notebook over synthetic research-article/author data. Puts both retrieval modes side by side, vector similarity and Cypher graph traversal, wired through LangChain, to answer collaboration- and topic-style questions.
+- [Neo4j RAG tutorial](https://neo4j.com/blog/developer/rag-tutorial/) — Neo4j developer blog.

--- a/reading-list/llm-inference.md
+++ b/reading-list/llm-inference.md
@@ -1,0 +1,7 @@
+# LLM inference — external links
+
+Curated reading list for LLM inference: serving, throughput, memory, and deployment.
+
+## Handbooks and references
+
+- [LLM Inference Handbook](https://handbook.modular.com/) — Modular. Consolidated glossary and guidebook for running LLMs in production, pulling together material otherwise scattered across papers, vendor docs, and community threads. Covers training vs inference, hardware platforms (CPU/GPU/TPU) and GPU architecture, performance metrics, quantization, continuous batching, prefix caching, prefill/decode disaggregation, KV cache management, GPU memory sizing, kernel optimization, and infra patterns (BYOC, on-prem). Includes interactive visualizers for token flow, latency timelines, batching strategies, and memory estimation.

--- a/time-series/anomaly-detection/images/phase1-acf-pacf-signatures.svg
+++ b/time-series/anomaly-detection/images/phase1-acf-pacf-signatures.svg
@@ -1,0 +1,183 @@
+<svg viewBox="0 0 900 520" xmlns="http://www.w3.org/2000/svg" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">
+  <defs>
+    <style>
+      .title { font-size: 14px; font-weight: 600; fill: #1a1a2e; }
+      .subtitle { font-size: 11px; fill: #6b7280; }
+      .label { font-size: 10px; fill: #374151; }
+      .axis-label { font-size: 9px; fill: #6b7280; }
+      .sig-band { fill: #dbeafe; opacity: 0.5; }
+      .bar-pos { fill: #2563eb; }
+      .bar-neg { fill: #2563eb; }
+      .sig-line { stroke: #93c5fd; stroke-width: 1; stroke-dasharray: 4,3; }
+      .axis-line { stroke: #d1d5db; stroke-width: 1; }
+      .zero-line { stroke: #9ca3af; stroke-width: 1; }
+      .annotation { font-size: 10px; fill: #dc2626; font-weight: 600; }
+      .panel-bg { fill: #fafbfc; stroke: #e5e7eb; stroke-width: 1; rx: 4; }
+    </style>
+  </defs>
+
+  <!-- Main title -->
+  <text x="450" y="28" text-anchor="middle" class="title" font-size="16">ACF / PACF Diagnostic Signatures</text>
+
+  <!-- Panel 1: AR(1) ACF — exponential decay -->
+  <rect x="20" y="45" width="420" height="210" class="panel-bg"/>
+  <text x="230" y="65" text-anchor="middle" class="title">AR(1) Process — ACF</text>
+  <text x="230" y="80" text-anchor="middle" class="subtitle">Exponential decay → tails off</text>
+
+  <!-- ACF axes -->
+  <line x1="60" y1="185" x2="410" y2="185" class="axis-line"/>
+  <line x1="60" y1="95" x2="60" y2="240" class="axis-line"/>
+  <text x="50" y="100" text-anchor="end" class="axis-label">1.0</text>
+  <text x="50" y="190" text-anchor="end" class="axis-label">0.0</text>
+  <text x="230" y="250" text-anchor="middle" class="axis-label">Lag</text>
+
+  <!-- Significance bands -->
+  <rect x="60" y="173" width="350" height="24" class="sig-band"/>
+  <line x1="60" y1="173" x2="410" y2="173" class="sig-line"/>
+  <line x1="60" y1="197" x2="410" y2="197" class="sig-line"/>
+
+  <!-- AR(1) ACF bars: exponential decay 0.8^k -->
+  <rect x="80" y="113" width="14" height="72" class="bar-pos"/>  <!-- lag 1: 0.8 -->
+  <rect x="110" y="127" width="14" height="58" class="bar-pos"/>  <!-- lag 2: 0.64 -->
+  <rect x="140" y="138" width="14" height="47" class="bar-pos"/>  <!-- lag 3: 0.512 -->
+  <rect x="170" y="147" width="14" height="38" class="bar-pos"/>  <!-- lag 4: 0.41 -->
+  <rect x="200" y="154" width="14" height="31" class="bar-pos"/>  <!-- lag 5: 0.33 -->
+  <rect x="230" y="159" width="14" height="26" class="bar-pos"/>  <!-- lag 6: 0.26 -->
+  <rect x="260" y="164" width="14" height="21" class="bar-pos"/>  <!-- lag 7: 0.21 -->
+  <rect x="290" y="167" width="14" height="18" class="bar-pos"/>  <!-- lag 8: 0.17 -->
+  <rect x="320" y="170" width="14" height="15" class="bar-pos"/>  <!-- lag 9: 0.13 -->
+  <rect x="350" y="173" width="14" height="12" class="bar-pos"/>  <!-- lag 10: 0.10 -->
+  <rect x="380" y="175" width="14" height="10" class="bar-pos"/>  <!-- lag 11: 0.08 -->
+
+  <!-- Lag labels -->
+  <text x="87" y="240" text-anchor="middle" class="axis-label">1</text>
+  <text x="147" y="240" text-anchor="middle" class="axis-label">3</text>
+  <text x="207" y="240" text-anchor="middle" class="axis-label">5</text>
+  <text x="267" y="240" text-anchor="middle" class="axis-label">7</text>
+  <text x="327" y="240" text-anchor="middle" class="axis-label">9</text>
+  <text x="387" y="240" text-anchor="middle" class="axis-label">11</text>
+
+  <!-- Decay curve annotation -->
+  <path d="M87,113 Q200,125 395,180" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="3,2"/>
+  <text x="300" y="140" class="annotation">Slow exponential decay</text>
+
+  <!-- Panel 2: AR(1) PACF — cuts off after lag 1 -->
+  <rect x="460" y="45" width="420" height="210" class="panel-bg"/>
+  <text x="670" y="65" text-anchor="middle" class="title">AR(1) Process — PACF</text>
+  <text x="670" y="80" text-anchor="middle" class="subtitle">Cuts off after lag 1</text>
+
+  <!-- PACF axes -->
+  <line x1="500" y1="185" x2="850" y2="185" class="axis-line"/>
+  <line x1="500" y1="95" x2="500" y2="240" class="axis-line"/>
+  <text x="490" y="100" text-anchor="end" class="axis-label">1.0</text>
+  <text x="490" y="190" text-anchor="end" class="axis-label">0.0</text>
+  <text x="670" y="250" text-anchor="middle" class="axis-label">Lag</text>
+
+  <!-- Significance bands -->
+  <rect x="500" y="173" width="350" height="24" class="sig-band"/>
+  <line x1="500" y1="173" x2="850" y2="173" class="sig-line"/>
+  <line x1="500" y1="197" x2="850" y2="197" class="sig-line"/>
+
+  <!-- AR(1) PACF bars: spike at 1, rest ~0 -->
+  <rect x="520" y="113" width="14" height="72" class="bar-pos"/>  <!-- lag 1: 0.8 -->
+  <rect x="550" y="182" width="14" height="3" class="bar-pos"/>
+  <rect x="580" y="183" width="14" height="4" class="bar-neg"/>
+  <rect x="610" y="184" width="14" height="2" class="bar-pos"/>
+  <rect x="640" y="182" width="14" height="3" class="bar-neg"/>
+  <rect x="670" y="183" width="14" height="2" class="bar-pos"/>
+  <rect x="700" y="184" width="14" height="3" class="bar-neg"/>
+  <rect x="730" y="183" width="14" height="2" class="bar-pos"/>
+  <rect x="760" y="182" width="14" height="3" class="bar-neg"/>
+  <rect x="790" y="184" width="14" height="2" class="bar-pos"/>
+  <rect x="820" y="183" width="14" height="3" class="bar-neg"/>
+
+  <text x="527" y="240" text-anchor="middle" class="axis-label">1</text>
+  <text x="587" y="240" text-anchor="middle" class="axis-label">3</text>
+  <text x="647" y="240" text-anchor="middle" class="axis-label">5</text>
+  <text x="707" y="240" text-anchor="middle" class="axis-label">7</text>
+  <text x="767" y="240" text-anchor="middle" class="axis-label">9</text>
+  <text x="827" y="240" text-anchor="middle" class="axis-label">11</text>
+
+  <text x="560" y="110" class="annotation">← Single significant spike</text>
+
+  <!-- Panel 3: MA(1) ACF — cuts off after lag 1 -->
+  <rect x="20" y="275" width="420" height="210" class="panel-bg"/>
+  <text x="230" y="295" text-anchor="middle" class="title">MA(1) Process — ACF</text>
+  <text x="230" y="310" text-anchor="middle" class="subtitle">Cuts off after lag 1</text>
+
+  <line x1="60" y1="415" x2="410" y2="415" class="axis-line"/>
+  <line x1="60" y1="325" x2="60" y2="470" class="axis-line"/>
+  <text x="50" y="330" text-anchor="end" class="axis-label">1.0</text>
+  <text x="50" y="420" text-anchor="end" class="axis-label">0.0</text>
+  <text x="230" y="480" text-anchor="middle" class="axis-label">Lag</text>
+
+  <rect x="60" y="403" width="350" height="24" class="sig-band"/>
+  <line x1="60" y1="403" x2="410" y2="403" class="sig-line"/>
+  <line x1="60" y1="427" x2="410" y2="427" class="sig-line"/>
+
+  <!-- MA(1) ACF bars: spike at 1, rest ~0 -->
+  <rect x="80" y="365" width="14" height="50" class="bar-neg"/>  <!-- lag 1: -0.55 -->
+  <rect x="110" y="412" width="14" height="3" class="bar-pos"/>
+  <rect x="140" y="413" width="14" height="4" class="bar-neg"/>
+  <rect x="170" y="414" width="14" height="2" class="bar-pos"/>
+  <rect x="200" y="412" width="14" height="3" class="bar-neg"/>
+  <rect x="230" y="413" width="14" height="2" class="bar-pos"/>
+  <rect x="260" y="414" width="14" height="3" class="bar-neg"/>
+  <rect x="290" y="413" width="14" height="2" class="bar-pos"/>
+  <rect x="320" y="412" width="14" height="3" class="bar-neg"/>
+  <rect x="350" y="414" width="14" height="2" class="bar-pos"/>
+  <rect x="380" y="413" width="14" height="3" class="bar-neg"/>
+
+  <text x="87" y="470" text-anchor="middle" class="axis-label">1</text>
+  <text x="147" y="470" text-anchor="middle" class="axis-label">3</text>
+  <text x="207" y="470" text-anchor="middle" class="axis-label">5</text>
+  <text x="267" y="470" text-anchor="middle" class="axis-label">7</text>
+  <text x="327" y="470" text-anchor="middle" class="axis-label">9</text>
+  <text x="387" y="470" text-anchor="middle" class="axis-label">11</text>
+
+  <text x="130" y="360" class="annotation">Single spike, then zero →</text>
+
+  <!-- Panel 4: MA(1) PACF — tails off -->
+  <rect x="460" y="275" width="420" height="210" class="panel-bg"/>
+  <text x="670" y="295" text-anchor="middle" class="title">MA(1) Process — PACF</text>
+  <text x="670" y="310" text-anchor="middle" class="subtitle">Alternating decay → tails off</text>
+
+  <line x1="500" y1="415" x2="850" y2="415" class="axis-line"/>
+  <line x1="500" y1="325" x2="500" y2="470" class="axis-line"/>
+  <text x="490" y="330" text-anchor="end" class="axis-label">1.0</text>
+  <text x="490" y="420" text-anchor="end" class="axis-label">0.0</text>
+  <text x="670" y="480" text-anchor="middle" class="axis-label">Lag</text>
+
+  <rect x="500" y="403" width="350" height="24" class="sig-band"/>
+  <line x1="500" y1="403" x2="850" y2="403" class="sig-line"/>
+  <line x1="500" y1="427" x2="850" y2="427" class="sig-line"/>
+
+  <!-- MA(1) PACF bars: alternating decay -->
+  <rect x="520" y="365" width="14" height="50" class="bar-neg"/>  <!-- lag 1: -0.55 -->
+  <rect x="550" y="395" width="14" height="20" class="bar-neg"/>  <!-- lag 2: -0.22 -->
+  <rect x="580" y="403" width="14" height="12" class="bar-neg"/>  <!-- lag 3: -0.13 -->
+  <rect x="610" y="407" width="14" height="8" class="bar-neg"/>
+  <rect x="640" y="410" width="14" height="5" class="bar-neg"/>
+  <rect x="670" y="411" width="14" height="4" class="bar-neg"/>
+  <rect x="700" y="412" width="14" height="3" class="bar-neg"/>
+  <rect x="730" y="413" width="14" height="3" class="bar-neg"/>
+  <rect x="760" y="413" width="14" height="2" class="bar-neg"/>
+  <rect x="790" y="413" width="14" height="2" class="bar-neg"/>
+  <rect x="820" y="414" width="14" height="2" class="bar-neg"/>
+
+  <text x="527" y="470" text-anchor="middle" class="axis-label">1</text>
+  <text x="587" y="470" text-anchor="middle" class="axis-label">3</text>
+  <text x="647" y="470" text-anchor="middle" class="axis-label">5</text>
+  <text x="707" y="470" text-anchor="middle" class="axis-label">7</text>
+  <text x="767" y="470" text-anchor="middle" class="axis-label">9</text>
+  <text x="827" y="470" text-anchor="middle" class="axis-label">11</text>
+
+  <path d="M527,365 Q650,395 830,415" fill="none" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="3,2"/>
+  <text x="740" y="375" class="annotation">Gradual decay</text>
+
+  <!-- Summary box -->
+  <rect x="20" y="495" width="860" height="20" rx="3" fill="#eff6ff" stroke="#bfdbfe"/>
+  <text x="450" y="509" text-anchor="middle" class="label" font-size="10">
+    Key rule: ACF reveals the total memory structure • PACF reveals the direct dependencies • Together they identify the model order
+  </text>
+</svg>

--- a/time-series/anomaly-detection/images/phase1-historian-alignment.svg
+++ b/time-series/anomaly-detection/images/phase1-historian-alignment.svg
@@ -1,0 +1,131 @@
+<svg viewBox="0 0 900 520" xmlns="http://www.w3.org/2000/svg" font-family="'Segoe UI', Arial, sans-serif">
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#555"/>
+    </marker>
+  </defs>
+
+  <text x="450" y="28" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a2e">Historian Data: Compression, Interpolation &amp; Alignment</text>
+
+  <!-- ROW 1: Raw vs Compressed -->
+  <rect x="15" y="45" width="430" height="185" rx="8" fill="#f0f4ff" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="230" y="68" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c3e6b">Raw Sensor Data (before compression)</text>
+
+  <!-- Raw signal axes -->
+  <line x1="50" y1="195" x2="410" y2="195" stroke="#888" stroke-width="1"/>
+  <line x1="50" y1="195" x2="50" y2="80" stroke="#888" stroke-width="1"/>
+
+  <!-- Raw signal - dense points along a curve -->
+  <polyline points="55,160 65,155 75,148 85,140 95,130 105,122 115,118 125,120 135,125 145,135 155,145 165,152 175,155 185,152 195,145 205,135 215,128 225,125 235,128 245,135 255,145 265,152 275,155 285,150 295,140 305,128 315,118 325,115 335,120 345,130 355,142 365,152 375,158 385,160 395,155 405,148" fill="none" stroke="#3366cc" stroke-width="1.5"/>
+  <!-- Dense dots -->
+  <g fill="#3366cc">
+    <circle cx="55" cy="160" r="2.5"/><circle cx="65" cy="155" r="2.5"/><circle cx="75" cy="148" r="2.5"/>
+    <circle cx="85" cy="140" r="2.5"/><circle cx="95" cy="130" r="2.5"/><circle cx="105" cy="122" r="2.5"/>
+    <circle cx="115" cy="118" r="2.5"/><circle cx="125" cy="120" r="2.5"/><circle cx="135" cy="125" r="2.5"/>
+    <circle cx="145" cy="135" r="2.5"/><circle cx="155" cy="145" r="2.5"/><circle cx="165" cy="152" r="2.5"/>
+    <circle cx="175" cy="155" r="2.5"/><circle cx="185" cy="152" r="2.5"/><circle cx="195" cy="145" r="2.5"/>
+    <circle cx="205" cy="135" r="2.5"/><circle cx="215" cy="128" r="2.5"/><circle cx="225" cy="125" r="2.5"/>
+    <circle cx="235" cy="128" r="2.5"/><circle cx="245" cy="135" r="2.5"/><circle cx="255" cy="145" r="2.5"/>
+    <circle cx="265" cy="152" r="2.5"/><circle cx="275" cy="155" r="2.5"/><circle cx="285" cy="150" r="2.5"/>
+    <circle cx="295" cy="140" r="2.5"/><circle cx="305" cy="128" r="2.5"/><circle cx="315" cy="118" r="2.5"/>
+    <circle cx="325" cy="115" r="2.5"/><circle cx="335" cy="120" r="2.5"/><circle cx="345" cy="130" r="2.5"/>
+    <circle cx="355" cy="142" r="2.5"/><circle cx="365" cy="152" r="2.5"/><circle cx="375" cy="158" r="2.5"/>
+    <circle cx="385" cy="160" r="2.5"/><circle cx="395" cy="155" r="2.5"/><circle cx="405" cy="148" r="2.5"/>
+  </g>
+  <text x="230" y="215" text-anchor="middle" font-size="10" fill="#666">Every sample stored — uniform spacing</text>
+
+  <!-- Arrow -->
+  <text x="450" y="130" text-anchor="middle" font-size="11" fill="#c0392b" font-weight="bold">Swinging</text>
+  <text x="450" y="145" text-anchor="middle" font-size="11" fill="#c0392b" font-weight="bold">Door</text>
+  <line x1="438" y1="155" x2="462" y2="155" stroke="#c0392b" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Compressed -->
+  <rect x="475" y="45" width="410" height="185" rx="8" fill="#fff5f0" stroke="#c0392b" stroke-width="1.5"/>
+  <text x="680" y="68" text-anchor="middle" font-size="13" font-weight="bold" fill="#8b2500">After Historian Compression</text>
+
+  <line x1="510" y1="195" x2="850" y2="195" stroke="#888" stroke-width="1"/>
+  <line x1="510" y1="195" x2="510" y2="80" stroke="#888" stroke-width="1"/>
+
+  <!-- Compressed: fewer points, connected by straight lines -->
+  <polyline points="515,160 575,118 635,155 695,125 755,115 815,158 850,148" fill="none" stroke="#e74c3c" stroke-width="1.5"/>
+  <g fill="#e74c3c">
+    <circle cx="515" cy="160" r="4"/><circle cx="575" cy="118" r="4"/>
+    <circle cx="635" cy="155" r="4"/><circle cx="695" cy="125" r="4"/>
+    <circle cx="755" cy="115" r="4"/><circle cx="815" cy="158" r="4"/>
+    <circle cx="850" cy="148" r="4"/>
+  </g>
+  <!-- Gap indicators -->
+  <line x1="515" y1="200" x2="575" y2="200" stroke="#e74c3c" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="545" y="212" text-anchor="middle" font-size="9" fill="#999">variable gaps</text>
+  <line x1="755" y1="200" x2="815" y2="200" stroke="#e74c3c" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="785" y="212" text-anchor="middle" font-size="9" fill="#999">large gap</text>
+
+  <text x="680" y="220" text-anchor="middle" font-size="10" fill="#666">Only "significant" changes stored — irregular spacing</text>
+
+  <!-- ROW 2: Interpolation Methods -->
+  <text x="450" y="260" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a1a2e">Interpolation Methods for Re-alignment</text>
+
+  <!-- Step interpolation -->
+  <rect x="15" y="275" width="280" height="145" rx="8" fill="#e8fde8" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="155" y="298" text-anchor="middle" font-size="12" font-weight="bold" fill="#1e7a1e">Step (ZOH) — Use for valves, setpoints</text>
+
+  <line x1="40" y1="395" x2="270" y2="395" stroke="#888" stroke-width="1"/>
+  <line x1="40" y1="395" x2="40" y2="305" stroke="#888" stroke-width="1"/>
+
+  <!-- Step function -->
+  <g fill="#27ae60">
+    <circle cx="50" cy="360" r="3.5"/><circle cx="110" cy="330" r="3.5"/>
+    <circle cx="180" cy="350" r="3.5"/><circle cx="240" cy="320" r="3.5"/>
+  </g>
+  <polyline points="50,360 110,360 110,330 180,330 180,350 240,350 240,320 265,320" fill="none" stroke="#27ae60" stroke-width="2"/>
+  <text x="155" y="413" text-anchor="middle" font-size="9" fill="#555">Holds last value until next change</text>
+
+  <!-- Linear interpolation -->
+  <rect x="310" y="275" width="280" height="145" rx="8" fill="#f0f4ff" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="450" y="298" text-anchor="middle" font-size="12" font-weight="bold" fill="#2c3e6b">Linear — Use for temperatures, flows</text>
+
+  <line x1="335" y1="395" x2="565" y2="395" stroke="#888" stroke-width="1"/>
+  <line x1="335" y1="395" x2="335" y2="305" stroke="#888" stroke-width="1"/>
+
+  <g fill="#4a6fa5">
+    <circle cx="345" cy="360" r="3.5"/><circle cx="405" cy="330" r="3.5"/>
+    <circle cx="475" cy="350" r="3.5"/><circle cx="535" cy="320" r="3.5"/>
+  </g>
+  <polyline points="345,360 405,330 475,350 535,320" fill="none" stroke="#4a6fa5" stroke-width="2"/>
+  <!-- Interpolated points -->
+  <g fill="#4a6fa5" opacity="0.4">
+    <circle cx="375" cy="345" r="2.5"/><circle cx="440" cy="340" r="2.5"/>
+    <circle cx="505" cy="335" r="2.5"/>
+  </g>
+  <text x="450" y="413" text-anchor="middle" font-size="9" fill="#555">Smooth interpolation between samples</text>
+
+  <!-- Alignment -->
+  <rect x="605" y="275" width="280" height="145" rx="8" fill="#f5f0ff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="745" y="298" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">Aligned Output Grid</text>
+
+  <line x1="630" y1="395" x2="860" y2="395" stroke="#888" stroke-width="1"/>
+  <line x1="630" y1="395" x2="630" y2="305" stroke="#888" stroke-width="1"/>
+
+  <!-- Uniform grid marks -->
+  <g stroke="#7c3aed" stroke-width="1" stroke-dasharray="2,3" opacity="0.4">
+    <line x1="660" y1="310" x2="660" y2="395"/>
+    <line x1="700" y1="310" x2="700" y2="395"/>
+    <line x1="740" y1="310" x2="740" y2="395"/>
+    <line x1="780" y1="310" x2="780" y2="395"/>
+    <line x1="820" y1="310" x2="820" y2="395"/>
+  </g>
+  <!-- Aligned points -->
+  <g fill="#7c3aed">
+    <circle cx="660" cy="358" r="3.5"/><circle cx="700" cy="340" r="3.5"/>
+    <circle cx="740" cy="335" r="3.5"/><circle cx="780" cy="345" r="3.5"/>
+    <circle cx="820" cy="325" r="3.5"/>
+  </g>
+  <polyline points="660,358 700,340 740,335 780,345 820,325" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-dasharray="4,2"/>
+  <text x="745" y="413" text-anchor="middle" font-size="9" fill="#555">Uniform timestamps for ML input</text>
+
+  <!-- Bottom warning box -->
+  <rect x="15" y="435" width="870" height="70" rx="8" fill="#fff8e1" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="450" y="458" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400e">⚠ Common Historian Pitfalls</text>
+  <text x="450" y="476" text-anchor="middle" font-size="10" fill="#333">Frozen values (sensor stuck) look like real data  •  Compression hides fast transients  •  Clock drift between systems → misaligned tags</text>
+  <text x="450" y="492" text-anchor="middle" font-size="10" fill="#333">Always check: Is a flat line real stasis or a dead sensor?  Is a gap missing data or no change?</text>
+</svg>

--- a/time-series/anomaly-detection/images/phase1-spectral-view.svg
+++ b/time-series/anomaly-detection/images/phase1-spectral-view.svg
@@ -1,0 +1,119 @@
+<svg viewBox="0 0 900 500" xmlns="http://www.w3.org/2000/svg" font-family="'Segoe UI', Arial, sans-serif">
+  <defs>
+    <linearGradient id="bg1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f0f4ff"/>
+      <stop offset="100%" stop-color="#e8eef8"/>
+    </linearGradient>
+    <linearGradient id="bg2" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fff5f0"/>
+      <stop offset="100%" stop-color="#faeae4"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Title -->
+  <text x="450" y="30" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a2e">Time Domain vs Frequency Domain (Power Spectral Density)</text>
+
+  <!-- LEFT PANEL: Time Domain -->
+  <rect x="20" y="50" width="420" height="200" rx="8" fill="url(#bg1)" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="230" y="75" text-anchor="middle" font-size="14" font-weight="bold" fill="#2c3e6b">Time Domain — Mixed Signal</text>
+
+  <!-- Axes -->
+  <line x1="60" y1="220" x2="410" y2="220" stroke="#555" stroke-width="1.5"/>
+  <line x1="60" y1="220" x2="60" y2="80" stroke="#555" stroke-width="1.5"/>
+  <text x="235" y="242" text-anchor="middle" font-size="11" fill="#555">Time (samples)</text>
+  <text x="45" y="150" text-anchor="middle" font-size="11" fill="#555" transform="rotate(-90,45,150)">Amplitude</text>
+
+  <!-- Composite signal: slow wave + fast wave + noise -->
+  <polyline points="
+    70,150 80,130 90,118 100,115 110,120 120,132 130,148 140,162 150,170 160,168 170,158 180,142 190,125 200,113 210,110 220,116 230,130 240,148 250,164 260,172 270,170 280,158 290,140 300,122 310,112 320,112 330,122 340,138 350,155 360,168 370,173 380,168 390,155 400,138
+  " fill="none" stroke="#3366cc" stroke-width="2"/>
+  <!-- Overlay faster oscillation -->
+  <polyline points="
+    70,150 75,144 80,135 85,128 90,122 95,118 100,118 105,122 110,128 115,130 120,136 125,140 130,148 135,154 140,160 145,166 150,170 155,168 160,164 165,160 170,154 175,148 180,138 185,132 190,125 195,118 200,114 205,112 210,114 215,118 220,122 225,128 230,136 235,142 240,150 245,156 250,164 255,170 260,172 265,170 270,166 275,160 280,154 285,146 290,138 295,130 300,122 305,116 310,114 315,114 320,118 325,124 330,130 335,138 340,144 345,150 350,158 355,164 360,170 365,174 370,172 375,168 380,162 385,156 390,148 395,142 400,136
+  " fill="none" stroke="#3366cc" stroke-width="1.8" opacity="0.7"/>
+
+  <text x="230" y="195" text-anchor="middle" font-size="11" fill="#3366cc" font-style="italic">y(t) = slow trend + 24h cycle + 8h cycle + noise</text>
+
+  <!-- Arrow between panels -->
+  <g transform="translate(440, 140)">
+    <rect x="0" y="0" width="30" height="30" rx="15" fill="#e74c3c" opacity="0.15"/>
+    <text x="15" y="14" text-anchor="middle" font-size="10" fill="#c0392b" font-weight="bold">FFT</text>
+    <path d="M5,22 L25,22" stroke="#c0392b" stroke-width="2" marker-end="url(#arrowRed)"/>
+  </g>
+  <defs>
+    <marker id="arrowRed" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#c0392b"/>
+    </marker>
+  </defs>
+
+  <!-- RIGHT PANEL: Frequency Domain -->
+  <rect x="480" y="50" width="400" height="200" rx="8" fill="url(#bg2)" stroke="#c0392b" stroke-width="1.5"/>
+  <text x="680" y="75" text-anchor="middle" font-size="14" font-weight="bold" fill="#8b2500">Frequency Domain — Power Spectral Density</text>
+
+  <!-- Axes -->
+  <line x1="520" y1="220" x2="850" y2="220" stroke="#555" stroke-width="1.5"/>
+  <line x1="520" y1="220" x2="520" y2="80" stroke="#555" stroke-width="1.5"/>
+  <text x="685" y="242" text-anchor="middle" font-size="11" fill="#555">Frequency (cycles / hour)</text>
+  <text x="505" y="150" text-anchor="middle" font-size="11" fill="#555" transform="rotate(-90,505,150)">Power</text>
+
+  <!-- PSD peaks -->
+  <!-- DC / trend component -->
+  <rect x="540" y="100" width="20" height="120" rx="3" fill="#e74c3c" opacity="0.7"/>
+  <text x="550" y="95" text-anchor="middle" font-size="9" fill="#8b2500">Trend</text>
+
+  <!-- 24h cycle peak -->
+  <rect x="620" y="120" width="20" height="100" rx="3" fill="#e74c3c" opacity="0.7"/>
+  <text x="630" y="112" text-anchor="middle" font-size="9" fill="#8b2500">1/24h</text>
+
+  <!-- 8h cycle peak -->
+  <rect x="720" y="150" width="20" height="70" rx="3" fill="#e74c3c" opacity="0.7"/>
+  <text x="730" y="142" text-anchor="middle" font-size="9" fill="#8b2500">1/8h</text>
+
+  <!-- Noise floor -->
+  <line x1="530" y1="210" x2="845" y2="210" stroke="#e74c3c" stroke-width="1" stroke-dasharray="4,3" opacity="0.5"/>
+  <text x="845" y="207" text-anchor="end" font-size="9" fill="#999">noise floor</text>
+
+  <!-- Small noise bumps -->
+  <rect x="570" y="200" width="12" height="20" rx="2" fill="#e74c3c" opacity="0.3"/>
+  <rect x="650" y="195" width="12" height="25" rx="2" fill="#e74c3c" opacity="0.3"/>
+  <rect x="690" y="198" width="12" height="22" rx="2" fill="#e74c3c" opacity="0.3"/>
+  <rect x="760" y="200" width="12" height="20" rx="2" fill="#e74c3c" opacity="0.3"/>
+  <rect x="800" y="202" width="12" height="18" rx="2" fill="#e74c3c" opacity="0.3"/>
+
+  <!-- BOTTOM: Key Concepts -->
+  <rect x="20" y="270" width="860" height="210" rx="8" fill="#fafafa" stroke="#ccc" stroke-width="1"/>
+  <text x="450" y="295" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a1a2e">Key Spectral Concepts for Industrial Data</text>
+
+  <!-- Nyquist -->
+  <rect x="40" y="310" width="250" height="75" rx="6" fill="#e8f4fd" stroke="#4a90d9" stroke-width="1"/>
+  <text x="165" y="332" text-anchor="middle" font-size="12" font-weight="bold" fill="#2c5282">Nyquist Frequency</text>
+  <text x="165" y="350" text-anchor="middle" font-size="10" fill="#333">f_Nyquist = f_sample / 2</text>
+  <text x="165" y="366" text-anchor="middle" font-size="10" fill="#555">Cannot detect cycles faster than</text>
+  <text x="165" y="380" text-anchor="middle" font-size="10" fill="#555">2× your sampling interval</text>
+
+  <!-- Aliasing -->
+  <rect x="320" y="310" width="250" height="75" rx="6" fill="#fdf2e8" stroke="#e67e22" stroke-width="1"/>
+  <text x="445" y="332" text-anchor="middle" font-size="12" font-weight="bold" fill="#a0522d">Aliasing</text>
+  <text x="445" y="350" text-anchor="middle" font-size="10" fill="#333">High-freq signal sampled too slowly</text>
+  <text x="445" y="366" text-anchor="middle" font-size="10" fill="#555">→ appears as a fake low-freq signal</text>
+  <text x="445" y="380" text-anchor="middle" font-size="10" fill="#555">Common with 1-min historian data</text>
+
+  <!-- Practical tip -->
+  <rect x="600" y="310" width="260" height="75" rx="6" fill="#e8fde8" stroke="#27ae60" stroke-width="1"/>
+  <text x="730" y="332" text-anchor="middle" font-size="12" font-weight="bold" fill="#1e7a1e">Industrial Rule of Thumb</text>
+  <text x="730" y="350" text-anchor="middle" font-size="10" fill="#333">Process time constant τ:</text>
+  <text x="730" y="366" text-anchor="middle" font-size="10" fill="#555">Sample at ≤ τ/10 for good dynamics</text>
+  <text x="730" y="380" text-anchor="middle" font-size="10" fill="#555">e.g., τ=5min → sample every 30s</text>
+
+  <!-- PSD interpretation -->
+  <rect x="40" y="400" width="530" height="65" rx="6" fill="#f5f0ff" stroke="#7c3aed" stroke-width="1"/>
+  <text x="305" y="422" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">Reading the PSD</text>
+  <text x="305" y="440" text-anchor="middle" font-size="10" fill="#333">Tall narrow peaks → periodic components (shift changes, day/night cycles, reactor oscillations)</text>
+  <text x="305" y="456" text-anchor="middle" font-size="10" fill="#333">Broad elevated regions → band-limited noise or quasi-periodic behaviour</text>
+
+  <!-- Flat floor note -->
+  <rect x="600" y="400" width="260" height="65" rx="6" fill="#fff5f5" stroke="#e53e3e" stroke-width="1"/>
+  <text x="730" y="422" text-anchor="middle" font-size="12" font-weight="bold" fill="#c53030">Watch For</text>
+  <text x="730" y="440" text-anchor="middle" font-size="10" fill="#333">Flat PSD → white noise (no structure)</text>
+  <text x="730" y="456" text-anchor="middle" font-size="10" fill="#333">1/f slope → integrated / drift process</text>
+</svg>

--- a/time-series/anomaly-detection/images/phase2-arima-selection.svg
+++ b/time-series/anomaly-detection/images/phase2-arima-selection.svg
@@ -1,0 +1,104 @@
+<svg viewBox="0 0 900 580" xmlns="http://www.w3.org/2000/svg" font-family="'Segoe UI', Arial, sans-serif">
+  <defs>
+    <marker id="a1" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#555"/>
+    </marker>
+    <marker id="aY" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#27ae60"/>
+    </marker>
+    <marker id="aN" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#e74c3c"/>
+    </marker>
+  </defs>
+
+  <text x="450" y="28" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a2e">ARIMA Model Selection Workflow</text>
+
+  <!-- Step 1: Start -->
+  <rect x="350" y="45" width="200" height="40" rx="20" fill="#4a6fa5" stroke="none"/>
+  <text x="450" y="70" text-anchor="middle" font-size="12" font-weight="bold" fill="white">Raw Time Series</text>
+
+  <line x1="450" y1="85" x2="450" y2="105" stroke="#555" stroke-width="1.5" marker-end="url(#a1)"/>
+
+  <!-- Step 2: Stationarity check -->
+  <polygon points="450,110 570,150 450,190 330,150" fill="#fff8e1" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="450" y="147" text-anchor="middle" font-size="11" font-weight="bold" fill="#92400e">Stationary?</text>
+  <text x="450" y="161" text-anchor="middle" font-size="9" fill="#92400e">ADF / KPSS test</text>
+
+  <!-- No branch: difference -->
+  <line x1="570" y1="150" x2="700" y2="150" stroke="#e74c3c" stroke-width="1.5" marker-end="url(#aN)"/>
+  <text x="630" y="142" text-anchor="middle" font-size="10" fill="#e74c3c" font-weight="bold">No</text>
+
+  <rect x="710" y="130" width="170" height="40" rx="6" fill="#fff5f0" stroke="#e74c3c" stroke-width="1.5"/>
+  <text x="795" y="147" text-anchor="middle" font-size="11" fill="#8b2500" font-weight="bold">Difference (d += 1)</text>
+  <text x="795" y="161" text-anchor="middle" font-size="9" fill="#8b2500">or log-transform</text>
+
+  <!-- Loop back -->
+  <path d="M795,170 L795,200 L450,200 L450,190" fill="none" stroke="#e74c3c" stroke-width="1.5" marker-end="url(#aN)"/>
+
+  <!-- Yes branch -->
+  <line x1="450" y1="190" x2="450" y2="225" stroke="#27ae60" stroke-width="1.5" marker-end="url(#aY)"/>
+  <text x="462" y="210" font-size="10" fill="#27ae60" font-weight="bold">Yes</text>
+
+  <!-- Step 3: ACF/PACF -->
+  <rect x="330" y="230" width="240" height="50" rx="6" fill="#e8f4fd" stroke="#4a90d9" stroke-width="1.5"/>
+  <text x="450" y="252" text-anchor="middle" font-size="12" font-weight="bold" fill="#2c5282">Examine ACF &amp; PACF</text>
+  <text x="450" y="268" text-anchor="middle" font-size="10" fill="#2c5282">of differenced series</text>
+
+  <!-- Three branches from ACF/PACF -->
+  <line x1="370" y1="280" x2="150" y2="330" stroke="#555" stroke-width="1.5" marker-end="url(#a1)"/>
+  <line x1="450" y1="280" x2="450" y2="330" stroke="#555" stroke-width="1.5" marker-end="url(#a1)"/>
+  <line x1="530" y1="280" x2="750" y2="330" stroke="#555" stroke-width="1.5" marker-end="url(#a1)"/>
+
+  <!-- AR pattern -->
+  <rect x="40" y="335" width="220" height="65" rx="6" fill="#e8fde8" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="150" y="355" text-anchor="middle" font-size="11" font-weight="bold" fill="#1e7a1e">AR(p) Pattern</text>
+  <text x="150" y="370" text-anchor="middle" font-size="9" fill="#333">ACF: tails off (decays)</text>
+  <text x="150" y="383" text-anchor="middle" font-size="9" fill="#333">PACF: cuts off at lag p</text>
+  <text x="150" y="396" text-anchor="middle" font-size="9" fill="#1e7a1e" font-weight="bold">→ ARIMA(p, d, 0)</text>
+
+  <!-- ARMA pattern -->
+  <rect x="330" y="335" width="240" height="65" rx="6" fill="#f5f0ff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="450" y="355" text-anchor="middle" font-size="11" font-weight="bold" fill="#5b21b6">Mixed ARMA Pattern</text>
+  <text x="450" y="370" text-anchor="middle" font-size="9" fill="#333">ACF: tails off</text>
+  <text x="450" y="383" text-anchor="middle" font-size="9" fill="#333">PACF: tails off</text>
+  <text x="450" y="396" text-anchor="middle" font-size="9" fill="#5b21b6" font-weight="bold">→ ARIMA(p, d, q) — try small p,q</text>
+
+  <!-- MA pattern -->
+  <rect x="640" y="335" width="220" height="65" rx="6" fill="#fff5f0" stroke="#e74c3c" stroke-width="1.5"/>
+  <text x="750" y="355" text-anchor="middle" font-size="11" font-weight="bold" fill="#8b2500">MA(q) Pattern</text>
+  <text x="750" y="370" text-anchor="middle" font-size="9" fill="#333">ACF: cuts off at lag q</text>
+  <text x="750" y="383" text-anchor="middle" font-size="9" fill="#333">PACF: tails off (decays)</text>
+  <text x="750" y="396" text-anchor="middle" font-size="9" fill="#8b2500" font-weight="bold">→ ARIMA(0, d, q)</text>
+
+  <!-- Converge to model selection -->
+  <line x1="150" y1="400" x2="350" y2="440" stroke="#555" stroke-width="1.5" marker-end="url(#a1)"/>
+  <line x1="450" y1="400" x2="450" y2="440" stroke="#555" stroke-width="1.5" marker-end="url(#a1)"/>
+  <line x1="750" y1="400" x2="550" y2="440" stroke="#555" stroke-width="1.5" marker-end="url(#a1)"/>
+
+  <!-- Step 4: Fit & Compare -->
+  <rect x="310" y="440" width="280" height="45" rx="6" fill="#fff8e1" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="450" y="460" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400e">Fit Candidate Models</text>
+  <text x="450" y="475" text-anchor="middle" font-size="10" fill="#92400e">Compare AIC / BIC (lower = better)</text>
+
+  <line x1="450" y1="485" x2="450" y2="505" stroke="#555" stroke-width="1.5" marker-end="url(#a1)"/>
+
+  <!-- Step 5: Residual check -->
+  <polygon points="450,510 570,540 450,570 330,540" fill="#e8f4fd" stroke="#4a90d9" stroke-width="1.5"/>
+  <text x="450" y="538" text-anchor="middle" font-size="10" font-weight="bold" fill="#2c5282">Residuals ≈</text>
+  <text x="450" y="552" text-anchor="middle" font-size="10" font-weight="bold" fill="#2c5282">white noise?</text>
+
+  <!-- Yes: done -->
+  <line x1="450" y1="570" x2="450" y2="578" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="462" y="578" font-size="10" fill="#27ae60" font-weight="bold">Yes → Deploy</text>
+
+  <!-- No: iterate -->
+  <line x1="570" y1="540" x2="680" y2="540" stroke="#e74c3c" stroke-width="1.5"/>
+  <text x="620" y="533" font-size="10" fill="#e74c3c" font-weight="bold">No</text>
+  <text x="730" y="537" text-anchor="middle" font-size="10" fill="#e74c3c">Adjust p,d,q</text>
+  <text x="730" y="552" text-anchor="middle" font-size="10" fill="#e74c3c">or try SARIMA</text>
+
+  <!-- Shortcut note -->
+  <rect x="20" y="450" width="250" height="40" rx="6" fill="#f9fafb" stroke="#ddd" stroke-width="1"/>
+  <text x="145" y="467" text-anchor="middle" font-size="10" fill="#555" font-style="italic">Shortcut: auto_arima (pmdarima)</text>
+  <text x="145" y="481" text-anchor="middle" font-size="10" fill="#555" font-style="italic">does grid search automatically</text>
+</svg>

--- a/time-series/anomaly-detection/images/phase2-kalman-cycle.svg
+++ b/time-series/anomaly-detection/images/phase2-kalman-cycle.svg
@@ -1,0 +1,76 @@
+<svg viewBox="0 0 900 440" xmlns="http://www.w3.org/2000/svg" font-family="'Segoe UI', Arial, sans-serif">
+  <defs>
+    <marker id="ak" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#4a6fa5"/>
+    </marker>
+    <marker id="akR" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#e74c3c"/>
+    </marker>
+  </defs>
+
+  <text x="450" y="28" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a2e">Kalman Filter: Predict–Update Cycle</text>
+
+  <!-- PREDICT box -->
+  <rect x="50" y="60" width="340" height="200" rx="10" fill="#e8f4fd" stroke="#4a90d9" stroke-width="2"/>
+  <text x="220" y="88" text-anchor="middle" font-size="15" font-weight="bold" fill="#2c5282">PREDICT</text>
+  <text x="220" y="105" text-anchor="middle" font-size="10" fill="#4a6fa5">(Time update — propagate state forward)</text>
+
+  <!-- Predict equations -->
+  <text x="80" y="140" font-size="12" fill="#333" font-weight="bold">State prediction:</text>
+  <text x="80" y="160" font-size="13" fill="#2c5282" font-family="'Courier New', monospace">x̂⁻ₖ = F · x̂ₖ₋₁</text>
+
+  <text x="80" y="195" font-size="12" fill="#333" font-weight="bold">Covariance prediction:</text>
+  <text x="80" y="215" font-size="13" fill="#2c5282" font-family="'Courier New', monospace">P⁻ₖ = F · Pₖ₋₁ · Fᵀ + Q</text>
+
+  <text x="80" y="245" font-size="10" fill="#666">F = state transition  |  Q = process noise</text>
+
+  <!-- UPDATE box -->
+  <rect x="510" y="60" width="370" height="200" rx="10" fill="#fff5f0" stroke="#e74c3c" stroke-width="2"/>
+  <text x="695" y="88" text-anchor="middle" font-size="15" font-weight="bold" fill="#c0392b">UPDATE</text>
+  <text x="695" y="105" text-anchor="middle" font-size="10" fill="#c0392b">(Measurement update — correct with observation)</text>
+
+  <!-- Update equations -->
+  <text x="530" y="135" font-size="12" fill="#333" font-weight="bold">Innovation (surprise):</text>
+  <text x="530" y="155" font-size="13" fill="#c0392b" font-family="'Courier New', monospace">ỹₖ = zₖ − H · x̂⁻ₖ</text>
+
+  <text x="530" y="180" font-size="12" fill="#333" font-weight="bold">Kalman gain:</text>
+  <text x="530" y="200" font-size="13" fill="#c0392b" font-family="'Courier New', monospace">Kₖ = P⁻ₖHᵀ(HP⁻ₖHᵀ + R)⁻¹</text>
+
+  <text x="530" y="225" font-size="12" fill="#333" font-weight="bold">Corrected state &amp; covariance:</text>
+  <text x="530" y="245" font-size="12" fill="#c0392b" font-family="'Courier New', monospace">x̂ₖ = x̂⁻ₖ + Kₖ · ỹₖ</text>
+
+  <!-- Arrows forming cycle -->
+  <!-- Predict → Update (top) -->
+  <path d="M390,120 L510,120" fill="none" stroke="#4a6fa5" stroke-width="2.5" marker-end="url(#ak)"/>
+  <text x="450" y="112" text-anchor="middle" font-size="10" fill="#4a6fa5" font-weight="bold">x̂⁻, P⁻</text>
+
+  <!-- Update → Predict (bottom, loop back) -->
+  <path d="M510,240 L390,240" fill="none" stroke="#e74c3c" stroke-width="2.5" marker-end="url(#akR)"/>
+  <text x="450" y="256" text-anchor="middle" font-size="10" fill="#c0392b" font-weight="bold">x̂, P</text>
+
+  <!-- Measurement input arrow -->
+  <line x1="695" y1="40" x2="695" y2="60" stroke="#27ae60" stroke-width="2.5" marker-end="url(#ak)"/>
+  <text x="695" y="36" text-anchor="middle" font-size="11" fill="#27ae60" font-weight="bold">Measurement zₖ</text>
+
+  <!-- ANOMALY DETECTION callout -->
+  <rect x="100" y="290" width="700" height="130" rx="10" fill="#f5f0ff" stroke="#7c3aed" stroke-width="2"/>
+  <text x="450" y="315" text-anchor="middle" font-size="14" font-weight="bold" fill="#5b21b6">Anomaly Detection via Innovation Sequence</text>
+
+  <!-- Three boxes inside -->
+  <rect x="120" y="330" width="200" height="75" rx="6" fill="white" stroke="#7c3aed" stroke-width="1"/>
+  <text x="220" y="352" text-anchor="middle" font-size="11" font-weight="bold" fill="#5b21b6">Innovation</text>
+  <text x="220" y="370" text-anchor="middle" font-size="10" fill="#333">ỹₖ = zₖ − H · x̂⁻ₖ</text>
+  <text x="220" y="386" text-anchor="middle" font-size="9" fill="#555">Expected: ~ N(0, Sₖ)</text>
+  <text x="220" y="400" text-anchor="middle" font-size="9" fill="#555">Sₖ = HP⁻ₖHᵀ + R</text>
+
+  <rect x="350" y="330" width="200" height="75" rx="6" fill="white" stroke="#7c3aed" stroke-width="1"/>
+  <text x="450" y="352" text-anchor="middle" font-size="11" font-weight="bold" fill="#5b21b6">Normalized Score</text>
+  <text x="450" y="370" text-anchor="middle" font-size="10" fill="#333">νₖ = ỹₖᵀ · Sₖ⁻¹ · ỹₖ</text>
+  <text x="450" y="388" text-anchor="middle" font-size="9" fill="#555">Should follow χ² distribution</text>
+
+  <rect x="580" y="330" width="200" height="75" rx="6" fill="white" stroke="#e74c3c" stroke-width="1.5"/>
+  <text x="680" y="352" text-anchor="middle" font-size="11" font-weight="bold" fill="#c0392b">Alert Condition</text>
+  <text x="680" y="370" text-anchor="middle" font-size="10" fill="#333">νₖ > threshold</text>
+  <text x="680" y="388" text-anchor="middle" font-size="9" fill="#c0392b">→ Anomaly detected!</text>
+  <text x="680" y="402" text-anchor="middle" font-size="9" fill="#555">Observation deviates from model</text>
+</svg>

--- a/time-series/anomaly-detection/images/phase3-anomaly-types.svg
+++ b/time-series/anomaly-detection/images/phase3-anomaly-types.svg
@@ -1,0 +1,109 @@
+<svg viewBox="0 0 900 430" xmlns="http://www.w3.org/2000/svg" font-family="'Segoe UI', Arial, sans-serif">
+  <text x="450" y="28" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a2e">Three Types of Time-Series Anomalies</text>
+
+  <!-- POINT ANOMALY -->
+  <rect x="15" y="50" width="280" height="240" rx="8" fill="#fff5f0" stroke="#e74c3c" stroke-width="1.5"/>
+  <text x="155" y="75" text-anchor="middle" font-size="14" font-weight="bold" fill="#c0392b">Point Anomaly</text>
+  <text x="155" y="92" text-anchor="middle" font-size="10" fill="#666">Single observation far from expected</text>
+
+  <!-- Axes -->
+  <line x1="40" y1="240" x2="270" y2="240" stroke="#888" stroke-width="1"/>
+  <line x1="40" y1="240" x2="40" y2="105" stroke="#888" stroke-width="1"/>
+
+  <!-- Normal signal -->
+  <polyline points="50,190 65,185 80,188 95,183 110,186 125,180 140,184 155,182 170,186 185,178 200,184 215,180 230,185 245,182 260,187" fill="none" stroke="#3366cc" stroke-width="2"/>
+  <g fill="#3366cc">
+    <circle cx="50" cy="190" r="2.5"/><circle cx="65" cy="185" r="2.5"/><circle cx="80" cy="188" r="2.5"/>
+    <circle cx="95" cy="183" r="2.5"/><circle cx="110" cy="186" r="2.5"/><circle cx="125" cy="180" r="2.5"/>
+    <circle cx="140" cy="184" r="2.5"/><circle cx="155" cy="182" r="2.5"/><circle cx="170" cy="186" r="2.5"/>
+    <circle cx="185" cy="178" r="2.5"/><circle cx="200" cy="184" r="2.5"/><circle cx="215" cy="180" r="2.5"/>
+    <circle cx="230" cy="185" r="2.5"/><circle cx="245" cy="182" r="2.5"/><circle cx="260" cy="187" r="2.5"/>
+  </g>
+
+  <!-- Anomalous point -->
+  <circle cx="155" cy="120" r="5" fill="#e74c3c" stroke="#c0392b" stroke-width="1.5"/>
+  <line x1="155" y1="125" x2="155" y2="182" stroke="#e74c3c" stroke-width="1" stroke-dasharray="3,2"/>
+
+  <!-- Label -->
+  <text x="175" y="118" font-size="10" fill="#c0392b" font-weight="bold">Spike!</text>
+
+  <text x="155" y="262" text-anchor="middle" font-size="10" fill="#333" font-weight="bold">Detection: z-score, Grubbs, IQR</text>
+  <text x="155" y="278" text-anchor="middle" font-size="9" fill="#555">e.g., sudden sensor glitch,</text>
+  <text x="155" y="290" text-anchor="middle" font-size="9" fill="#555">instrument spike, data entry error</text>
+
+  <!-- CONTEXTUAL ANOMALY -->
+  <rect x="310" y="50" width="280" height="240" rx="8" fill="#e8f4fd" stroke="#4a90d9" stroke-width="1.5"/>
+  <text x="450" y="75" text-anchor="middle" font-size="14" font-weight="bold" fill="#2c5282">Contextual Anomaly</text>
+  <text x="450" y="92" text-anchor="middle" font-size="10" fill="#666">Normal value, wrong context</text>
+
+  <!-- Axes -->
+  <line x1="335" y1="240" x2="565" y2="240" stroke="#888" stroke-width="1"/>
+  <line x1="335" y1="240" x2="335" y2="105" stroke="#888" stroke-width="1"/>
+
+  <!-- Seasonal pattern -->
+  <polyline points="345,200 355,190 365,175 375,160 385,150 395,148 405,155 415,168 425,185 435,200 445,210 455,200 465,188 475,170 485,155 495,145 505,143 515,150 525,165 535,180 545,195 555,208" fill="none" stroke="#3366cc" stroke-width="2"/>
+
+  <!-- Anomalous segment: value normal globally but wrong for this time -->
+  <polyline points="455,200 465,188 475,170" fill="none" stroke="#3366cc" stroke-width="2" opacity="0"/>
+  <polyline points="455,200 465,210 475,220" fill="none" stroke="#e74c3c" stroke-width="2.5"/>
+  <circle cx="465" cy="210" r="4" fill="#e74c3c"/>
+  <circle cx="475" cy="220" r="4" fill="#e74c3c"/>
+
+  <!-- Expected range band -->
+  <rect x="450" y="155" width="30" height="55" rx="3" fill="#4a90d9" opacity="0.1" stroke="#4a90d9" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="495" y="175" font-size="9" fill="#4a90d9">expected</text>
+  <text x="495" y="185" font-size="9" fill="#4a90d9">range here</text>
+
+  <text x="475" y="235" font-size="9" fill="#c0392b" font-weight="bold">↑ Wrong for this phase</text>
+
+  <text x="450" y="262" text-anchor="middle" font-size="10" fill="#333" font-weight="bold">Detection: seasonal models, STL</text>
+  <text x="450" y="278" text-anchor="middle" font-size="9" fill="#555">e.g., night-shift temp during day,</text>
+  <text x="450" y="290" text-anchor="middle" font-size="9" fill="#555">summer value in winter window</text>
+
+  <!-- COLLECTIVE ANOMALY -->
+  <rect x="605" y="50" width="280" height="240" rx="8" fill="#e8fde8" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="745" y="75" text-anchor="middle" font-size="14" font-weight="bold" fill="#1e7a1e">Collective Anomaly</text>
+  <text x="745" y="92" text-anchor="middle" font-size="10" fill="#666">Sequence of points abnormal together</text>
+
+  <!-- Axes -->
+  <line x1="630" y1="240" x2="860" y2="240" stroke="#888" stroke-width="1"/>
+  <line x1="630" y1="240" x2="630" y2="105" stroke="#888" stroke-width="1"/>
+
+  <!-- Normal signal -->
+  <polyline points="640,185 655,180 670,188 685,182 700,186" fill="none" stroke="#3366cc" stroke-width="2"/>
+  <polyline points="800,184 815,180 830,186 845,183" fill="none" stroke="#3366cc" stroke-width="2"/>
+
+  <!-- Anomalous subsequence -->
+  <rect x="700" y="115" width="100" height="130" rx="4" fill="#e74c3c" opacity="0.08" stroke="#e74c3c" stroke-width="1" stroke-dasharray="4,3"/>
+  <polyline points="700,186 710,170 720,155 725,148 730,155 735,145 740,138 745,145 750,135 755,142 760,148 770,155 780,165 790,175 800,184" fill="none" stroke="#e74c3c" stroke-width="2.5"/>
+
+  <text x="750" y="130" text-anchor="middle" font-size="9" fill="#c0392b" font-weight="bold">Unusual pattern</text>
+  <text x="750" y="142" text-anchor="middle" font-size="9" fill="#c0392b">(each point ok alone)</text>
+
+  <text x="745" y="262" text-anchor="middle" font-size="10" fill="#333" font-weight="bold">Detection: Matrix Profile, HMM</text>
+  <text x="745" y="278" text-anchor="middle" font-size="9" fill="#555">e.g., unusual oscillation pattern,</text>
+  <text x="745" y="290" text-anchor="middle" font-size="9" fill="#555">slow drift sequence, micro-stalls</text>
+
+  <!-- Bottom comparison -->
+  <rect x="15" y="310" width="870" height="105" rx="8" fill="#fafafa" stroke="#ccc" stroke-width="1"/>
+  <text x="450" y="335" text-anchor="middle" font-size="13" font-weight="bold" fill="#1a1a2e">Industrial Context: Why This Taxonomy Matters</text>
+
+  <text x="155" y="360" text-anchor="middle" font-size="10" fill="#c0392b" font-weight="bold">Point</text>
+  <text x="155" y="376" text-anchor="middle" font-size="9" fill="#333">Instrument failure, communication</text>
+  <text x="155" y="390" text-anchor="middle" font-size="9" fill="#333">dropout, or data corruption</text>
+  <text x="155" y="406" text-anchor="middle" font-size="9" fill="#555" font-style="italic">→ Often filter/ignore in preprocessing</text>
+
+  <line x1="305" y1="350" x2="305" y2="410" stroke="#ddd" stroke-width="1"/>
+
+  <text x="450" y="360" text-anchor="middle" font-size="10" fill="#2c5282" font-weight="bold">Contextual</text>
+  <text x="450" y="376" text-anchor="middle" font-size="9" fill="#333">Operating mode mismatch, wrong</text>
+  <text x="450" y="390" text-anchor="middle" font-size="9" fill="#333">setpoint for current regime</text>
+  <text x="450" y="406" text-anchor="middle" font-size="9" fill="#555" font-style="italic">→ Requires regime-aware models</text>
+
+  <line x1="600" y1="350" x2="600" y2="410" stroke="#ddd" stroke-width="1"/>
+
+  <text x="745" y="360" text-anchor="middle" font-size="10" fill="#1e7a1e" font-weight="bold">Collective</text>
+  <text x="745" y="376" text-anchor="middle" font-size="9" fill="#333">Emerging degradation, catalyst</text>
+  <text x="745" y="390" text-anchor="middle" font-size="9" fill="#333">deactivation, fouling progression</text>
+  <text x="745" y="406" text-anchor="middle" font-size="9" fill="#555" font-style="italic">→ Most operationally important</text>
+</svg>

--- a/time-series/anomaly-detection/images/phase3-autoencoder-anomaly.svg
+++ b/time-series/anomaly-detection/images/phase3-autoencoder-anomaly.svg
@@ -1,0 +1,145 @@
+<svg viewBox="0 0 900 480" xmlns="http://www.w3.org/2000/svg" font-family="'Segoe UI', Arial, sans-serif">
+  <defs>
+    <marker id="ae" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#4a6fa5"/>
+    </marker>
+  </defs>
+
+  <text x="450" y="28" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a2e">Autoencoder-Based Anomaly Detection</text>
+
+  <!-- ARCHITECTURE SECTION -->
+  <!-- Input layer -->
+  <text x="65" y="60" text-anchor="middle" font-size="11" font-weight="bold" fill="#2c5282">Input</text>
+  <text x="65" y="73" text-anchor="middle" font-size="9" fill="#666">n sensors</text>
+  <g fill="#4a90d9">
+    <circle cx="65" cy="95" r="10" opacity="0.7"/><circle cx="65" cy="125" r="10" opacity="0.7"/>
+    <circle cx="65" cy="155" r="10" opacity="0.7"/><circle cx="65" cy="185" r="10" opacity="0.7"/>
+    <circle cx="65" cy="215" r="10" opacity="0.7"/><circle cx="65" cy="245" r="10" opacity="0.7"/>
+  </g>
+  <text x="65" y="99" text-anchor="middle" font-size="8" fill="white">T₁</text>
+  <text x="65" y="129" text-anchor="middle" font-size="8" fill="white">P₁</text>
+  <text x="65" y="159" text-anchor="middle" font-size="8" fill="white">F₁</text>
+  <text x="65" y="189" text-anchor="middle" font-size="8" fill="white">T₂</text>
+  <text x="65" y="219" text-anchor="middle" font-size="8" fill="white">P₂</text>
+  <text x="65" y="249" text-anchor="middle" font-size="8" fill="white">F₂</text>
+
+  <!-- Encoder hidden 1 -->
+  <g fill="#6a8fc7">
+    <circle cx="175" cy="115" r="9" opacity="0.6"/><circle cx="175" cy="150" r="9" opacity="0.6"/>
+    <circle cx="175" cy="185" r="9" opacity="0.6"/><circle cx="175" cy="220" r="9" opacity="0.6"/>
+  </g>
+
+  <!-- Connections input → hidden1 (simplified) -->
+  <g stroke="#4a90d9" stroke-width="0.5" opacity="0.3">
+    <line x1="75" y1="95" x2="166" y2="115"/><line x1="75" y1="125" x2="166" y2="115"/>
+    <line x1="75" y1="155" x2="166" y2="150"/><line x1="75" y1="185" x2="166" y2="185"/>
+    <line x1="75" y1="215" x2="166" y2="220"/><line x1="75" y1="245" x2="166" y2="220"/>
+    <line x1="75" y1="95" x2="166" y2="150"/><line x1="75" y1="245" x2="166" y2="185"/>
+  </g>
+
+  <!-- Bottleneck (latent) -->
+  <rect x="260" y="135" width="50" height="80" rx="6" fill="#7c3aed" opacity="0.15" stroke="#7c3aed" stroke-width="1.5"/>
+  <g fill="#7c3aed">
+    <circle cx="285" cy="155" r="9"/><circle cx="285" cy="195" r="9"/>
+  </g>
+  <text x="285" y="159" text-anchor="middle" font-size="7" fill="white">z₁</text>
+  <text x="285" y="199" text-anchor="middle" font-size="7" fill="white">z₂</text>
+  <text x="285" y="130" text-anchor="middle" font-size="9" font-weight="bold" fill="#5b21b6">Latent</text>
+
+  <!-- Connections hidden1 → bottleneck -->
+  <g stroke="#6a8fc7" stroke-width="0.5" opacity="0.3">
+    <line x1="184" y1="115" x2="276" y2="155"/><line x1="184" y1="150" x2="276" y2="155"/>
+    <line x1="184" y1="185" x2="276" y2="195"/><line x1="184" y1="220" x2="276" y2="195"/>
+  </g>
+
+  <!-- Decoder hidden 1 -->
+  <g fill="#6a8fc7">
+    <circle cx="395" cy="115" r="9" opacity="0.6"/><circle cx="395" cy="150" r="9" opacity="0.6"/>
+    <circle cx="395" cy="185" r="9" opacity="0.6"/><circle cx="395" cy="220" r="9" opacity="0.6"/>
+  </g>
+
+  <!-- Connections bottleneck → decoder hidden -->
+  <g stroke="#7c3aed" stroke-width="0.5" opacity="0.3">
+    <line x1="294" y1="155" x2="386" y2="115"/><line x1="294" y1="155" x2="386" y2="150"/>
+    <line x1="294" y1="195" x2="386" y2="185"/><line x1="294" y1="195" x2="386" y2="220"/>
+  </g>
+
+  <!-- Output layer -->
+  <text x="505" y="60" text-anchor="middle" font-size="11" font-weight="bold" fill="#c0392b">Reconstruction</text>
+  <text x="505" y="73" text-anchor="middle" font-size="9" fill="#666">x̂ ≈ x</text>
+  <g fill="#e74c3c">
+    <circle cx="505" cy="95" r="10" opacity="0.7"/><circle cx="505" cy="125" r="10" opacity="0.7"/>
+    <circle cx="505" cy="155" r="10" opacity="0.7"/><circle cx="505" cy="185" r="10" opacity="0.7"/>
+    <circle cx="505" cy="215" r="10" opacity="0.7"/><circle cx="505" cy="245" r="10" opacity="0.7"/>
+  </g>
+  <text x="505" y="99" text-anchor="middle" font-size="8" fill="white">T̂₁</text>
+  <text x="505" y="129" text-anchor="middle" font-size="8" fill="white">P̂₁</text>
+  <text x="505" y="159" text-anchor="middle" font-size="8" fill="white">F̂₁</text>
+  <text x="505" y="189" text-anchor="middle" font-size="8" fill="white">T̂₂</text>
+  <text x="505" y="219" text-anchor="middle" font-size="8" fill="white">P̂₂</text>
+  <text x="505" y="249" text-anchor="middle" font-size="8" fill="white">F̂₂</text>
+
+  <!-- Connections decoder → output -->
+  <g stroke="#e74c3c" stroke-width="0.5" opacity="0.3">
+    <line x1="404" y1="115" x2="495" y2="95"/><line x1="404" y1="115" x2="495" y2="125"/>
+    <line x1="404" y1="150" x2="495" y2="155"/><line x1="404" y1="185" x2="495" y2="185"/>
+    <line x1="404" y1="220" x2="495" y2="215"/><line x1="404" y1="220" x2="495" y2="245"/>
+  </g>
+
+  <!-- Labels -->
+  <text x="165" y="260" text-anchor="middle" font-size="10" fill="#4a6fa5" font-weight="bold">ENCODER</text>
+  <path d="M90,270 L90,268 L260,268 L260,270" fill="none" stroke="#4a6fa5" stroke-width="1"/>
+
+  <text x="400" y="260" text-anchor="middle" font-size="10" fill="#e74c3c" font-weight="bold">DECODER</text>
+  <path d="M310,270 L310,268 L490,268 L490,270" fill="none" stroke="#e74c3c" stroke-width="1"/>
+
+  <!-- RIGHT SIDE: Reconstruction Error -->
+  <rect x="560" y="55" width="325" height="210" rx="8" fill="#f5f0ff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="722" y="78" text-anchor="middle" font-size="13" font-weight="bold" fill="#5b21b6">Reconstruction Error Over Time</text>
+
+  <!-- Mini time series of reconstruction error -->
+  <line x1="585" y1="230" x2="860" y2="230" stroke="#888" stroke-width="1"/>
+  <line x1="585" y1="230" x2="585" y2="90" stroke="#888" stroke-width="1"/>
+  <text x="722" y="248" text-anchor="middle" font-size="9" fill="#666">Time</text>
+  <text x="575" y="160" text-anchor="middle" font-size="9" fill="#666" transform="rotate(-90,575,160)">‖x − x̂‖²</text>
+
+  <!-- Normal error (low, noisy) -->
+  <polyline points="595,210 605,208 615,212 625,206 635,210 645,205 655,209 665,207 675,211 685,204 695,208 705,206 715,210 725,205 735,180 745,155 755,130 765,110 775,105 785,115 795,140 805,165 815,195 825,208 835,205 845,210 855,207" fill="none" stroke="#7c3aed" stroke-width="2"/>
+
+  <!-- Threshold line -->
+  <line x1="585" y1="170" x2="860" y2="170" stroke="#e74c3c" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="862" y="167" font-size="9" fill="#e74c3c" font-weight="bold">threshold</text>
+
+  <!-- Anomaly region highlight -->
+  <rect x="730" y="90" width="65" height="140" rx="3" fill="#e74c3c" opacity="0.08"/>
+  <text x="762" y="100" text-anchor="middle" font-size="9" fill="#c0392b" font-weight="bold">ANOMALY</text>
+
+  <!-- Normal label -->
+  <text x="650" y="196" text-anchor="middle" font-size="9" fill="#27ae60" font-weight="bold">Normal</text>
+  <text x="650" y="208" text-anchor="middle" font-size="8" fill="#555">low error = learned pattern</text>
+
+  <!-- BOTTOM: Key Insight Boxes -->
+  <rect x="15" y="290" width="280" height="85" rx="8" fill="#e8fde8" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="155" y="312" text-anchor="middle" font-size="12" font-weight="bold" fill="#1e7a1e">Training: Normal Data Only</text>
+  <text x="155" y="330" text-anchor="middle" font-size="10" fill="#333">AE learns to compress &amp; reconstruct</text>
+  <text x="155" y="345" text-anchor="middle" font-size="10" fill="#333">normal operating patterns.</text>
+  <text x="155" y="362" text-anchor="middle" font-size="9" fill="#555" font-style="italic">Semi-supervised: no anomaly labels needed</text>
+
+  <rect x="310" y="290" width="280" height="85" rx="8" fill="#fff5f0" stroke="#e74c3c" stroke-width="1.5"/>
+  <text x="450" y="312" text-anchor="middle" font-size="12" font-weight="bold" fill="#c0392b">Inference: Error = Anomaly Score</text>
+  <text x="450" y="330" text-anchor="middle" font-size="10" fill="#333">Novel/abnormal patterns can't be</text>
+  <text x="450" y="345" text-anchor="middle" font-size="10" fill="#333">reconstructed well → high error.</text>
+  <text x="450" y="362" text-anchor="middle" font-size="9" fill="#555" font-style="italic">Per-sensor error → which variable is off?</text>
+
+  <rect x="605" y="290" width="280" height="85" rx="8" fill="#fff8e1" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="745" y="312" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400e">Industrial Strengths</text>
+  <text x="745" y="330" text-anchor="middle" font-size="10" fill="#333">Handles 100s of correlated sensors.</text>
+  <text x="745" y="345" text-anchor="middle" font-size="10" fill="#333">Captures nonlinear relationships.</text>
+  <text x="745" y="362" text-anchor="middle" font-size="9" fill="#555" font-style="italic">Watch: retraining needed for new regimes</text>
+
+  <!-- Bottom summary -->
+  <rect x="15" y="395" width="870" height="70" rx="8" fill="#fafafa" stroke="#ccc" stroke-width="1"/>
+  <text x="450" y="418" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a1a2e">Threshold Selection Strategy</text>
+  <text x="450" y="438" text-anchor="middle" font-size="10" fill="#333">Train on clean normal data → compute error on validation set → set threshold at percentile (e.g., 99th or 99.5th)</text>
+  <text x="450" y="454" text-anchor="middle" font-size="10" fill="#555">Or use dynamic threshold: flag when error exceeds μ + k·σ of a rolling window of recent errors</text>
+</svg>

--- a/time-series/anomaly-detection/images/phase4-changepoint-methods.svg
+++ b/time-series/anomaly-detection/images/phase4-changepoint-methods.svg
@@ -1,0 +1,175 @@
+<svg viewBox="0 0 900 530" xmlns="http://www.w3.org/2000/svg" font-family="'Segoe UI', Arial, sans-serif">
+  <text x="450" y="28" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a2e">Change-Point Detection: CUSUM, PELT &amp; BOCPD</text>
+
+  <!-- Shared signal at top -->
+  <rect x="15" y="45" width="870" height="120" rx="8" fill="#fafafa" stroke="#ccc" stroke-width="1"/>
+  <text x="450" y="65" text-anchor="middle" font-size="12" font-weight="bold" fill="#333">Input: Process Signal with Two Change Points</text>
+
+  <line x1="50" y1="140" x2="850" y2="140" stroke="#888" stroke-width="1"/>
+  <line x1="50" y1="140" x2="50" y2="72" stroke="#888" stroke-width="1"/>
+
+  <!-- Segment 1: mean ~110 -->
+  <polyline points="60,108 80,112 100,106 120,110 140,108 160,112 180,105 200,110 220,108 240,112 260,106 280,110" fill="none" stroke="#3366cc" stroke-width="2"/>
+  <!-- Segment 2: mean ~95 (shift down) -->
+  <polyline points="280,110 300,96 320,92 340,98 360,94 380,90 400,96 420,92 440,95 460,90 480,94 500,92 520,96" fill="none" stroke="#3366cc" stroke-width="2"/>
+  <!-- Segment 3: mean ~80, more variance -->
+  <polyline points="520,96 540,82 560,76 580,85 600,72 620,80 640,74 660,86 680,78 700,70 720,82 740,76 760,84 780,72 800,80 820,76 840,82" fill="none" stroke="#3366cc" stroke-width="2"/>
+
+  <!-- Change point markers -->
+  <line x1="280" y1="70" x2="280" y2="140" stroke="#e74c3c" stroke-width="2" stroke-dasharray="4,3"/>
+  <text x="280" y="155" text-anchor="middle" font-size="9" fill="#e74c3c" font-weight="bold">CP₁</text>
+  <line x1="520" y1="70" x2="520" y2="140" stroke="#e74c3c" stroke-width="2" stroke-dasharray="4,3"/>
+  <text x="520" y="155" text-anchor="middle" font-size="9" fill="#e74c3c" font-weight="bold">CP₂</text>
+
+  <!-- Segment labels -->
+  <text x="170" y="84" text-anchor="middle" font-size="9" fill="#666">μ₁, σ₁</text>
+  <text x="400" y="84" text-anchor="middle" font-size="9" fill="#666">μ₂ (shift down)</text>
+  <text x="680" y="86" text-anchor="middle" font-size="9" fill="#666">μ₃, σ₃↑ (mean + variance shift)</text>
+
+  <!-- METHOD 1: CUSUM -->
+  <rect x="15" y="175" width="280" height="180" rx="8" fill="#e8f4fd" stroke="#4a90d9" stroke-width="1.5"/>
+  <text x="155" y="198" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c5282">CUSUM</text>
+  <text x="155" y="213" text-anchor="middle" font-size="9" fill="#4a6fa5">Cumulative Sum Control Chart</text>
+
+  <!-- CUSUM statistic plot -->
+  <line x1="35" y1="330" x2="275" y2="330" stroke="#888" stroke-width="1"/>
+  <line x1="35" y1="330" x2="35" y2="225" stroke="#888" stroke-width="1"/>
+
+  <!-- Cumulative sum rising after change -->
+  <polyline points="45,320 65,318 85,322 105,316 125,320 145,315 155,300 165,280 175,265 185,255 195,242 205,250 215,240 225,248 235,235 245,240 255,228 265,232" fill="none" stroke="#4a90d9" stroke-width="2"/>
+
+  <!-- Threshold -->
+  <line x1="35" y1="260" x2="275" y2="260" stroke="#e74c3c" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="270" y="255" text-anchor="end" font-size="8" fill="#e74c3c">h (threshold)</text>
+
+  <!-- Alert marker -->
+  <circle cx="185" cy="255" r="4" fill="#e74c3c"/>
+  <text x="195" y="250" font-size="8" fill="#e74c3c" font-weight="bold">Alert!</text>
+
+  <text x="155" y="348" text-anchor="middle" font-size="9" fill="#333" font-weight="bold">Online • Sequential • One-at-a-time</text>
+
+  <!-- METHOD 2: PELT -->
+  <rect x="310" y="175" width="280" height="180" rx="8" fill="#e8fde8" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="450" y="198" text-anchor="middle" font-size="13" font-weight="bold" fill="#1e7a1e">PELT</text>
+  <text x="450" y="213" text-anchor="middle" font-size="9" fill="#27ae60">Pruned Exact Linear Time</text>
+
+  <!-- Segmented signal -->
+  <line x1="330" y1="330" x2="570" y2="330" stroke="#888" stroke-width="1"/>
+  <line x1="330" y1="330" x2="330" y2="225" stroke="#888" stroke-width="1"/>
+
+  <!-- Three segments with fitted means -->
+  <polyline points="340,280 360,283 380,278 400,282 410,280" fill="none" stroke="#aaa" stroke-width="1"/>
+  <line x1="340" y1="280" x2="410" y2="280" stroke="#27ae60" stroke-width="2"/>
+
+  <polyline points="415,295 430,292 445,298 460,294 475,296 490,293" fill="none" stroke="#aaa" stroke-width="1"/>
+  <line x1="415" y1="295" x2="490" y2="295" stroke="#27ae60" stroke-width="2"/>
+
+  <polyline points="495,308 510,302 525,312 540,305 555,310" fill="none" stroke="#aaa" stroke-width="1"/>
+  <line x1="495" y1="308" x2="560" y2="308" stroke="#27ae60" stroke-width="2"/>
+
+  <!-- Change point lines -->
+  <line x1="412" y1="240" x2="412" y2="325" stroke="#e74c3c" stroke-width="1.5" stroke-dasharray="3,2"/>
+  <line x1="493" y1="240" x2="493" y2="325" stroke="#e74c3c" stroke-width="1.5" stroke-dasharray="3,2"/>
+
+  <!-- Cost annotation -->
+  <text x="375" y="255" text-anchor="middle" font-size="8" fill="#1e7a1e">C₁</text>
+  <text x="452" y="255" text-anchor="middle" font-size="8" fill="#1e7a1e">C₂</text>
+  <text x="528" y="255" text-anchor="middle" font-size="8" fill="#1e7a1e">C₃</text>
+  <text x="450" y="245" text-anchor="middle" font-size="8" fill="#555">min Σ C(seg) + penalty</text>
+
+  <text x="450" y="348" text-anchor="middle" font-size="9" fill="#333" font-weight="bold">Offline • Batch • All CPs at once</text>
+
+  <!-- METHOD 3: BOCPD -->
+  <rect x="605" y="175" width="280" height="180" rx="8" fill="#f5f0ff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="745" y="198" text-anchor="middle" font-size="13" font-weight="bold" fill="#5b21b6">BOCPD</text>
+  <text x="745" y="213" text-anchor="middle" font-size="9" fill="#7c3aed">Bayesian Online Change-Point Detection</text>
+
+  <!-- Run-length probability heatmap (simplified) -->
+  <line x1="625" y1="330" x2="865" y2="330" stroke="#888" stroke-width="1"/>
+  <line x1="625" y1="330" x2="625" y2="225" stroke="#888" stroke-width="1"/>
+  <text x="745" y="342" text-anchor="middle" font-size="8" fill="#666">Time</text>
+  <text x="618" y="278" text-anchor="middle" font-size="8" fill="#666" transform="rotate(-90,618,278)">Run length</text>
+
+  <!-- Simplified heatmap: diagonal lines showing run length growing, resetting at CPs -->
+  <!-- Run 1 -->
+  <g opacity="0.6">
+    <rect x="635" y="320" width="8" height="8" fill="#7c3aed" opacity="0.8"/>
+    <rect x="645" y="312" width="8" height="16" fill="#7c3aed" opacity="0.7"/>
+    <rect x="655" y="304" width="8" height="24" fill="#7c3aed" opacity="0.6"/>
+    <rect x="665" y="296" width="8" height="32" fill="#7c3aed" opacity="0.5"/>
+    <rect x="675" y="288" width="8" height="40" fill="#7c3aed" opacity="0.4"/>
+    <rect x="685" y="280" width="8" height="48" fill="#7c3aed" opacity="0.35"/>
+    <rect x="695" y="272" width="8" height="56" fill="#7c3aed" opacity="0.3"/>
+    <rect x="705" y="264" width="8" height="64" fill="#7c3aed" opacity="0.25"/>
+  </g>
+  <!-- Reset at CP1 -->
+  <rect x="715" y="320" width="8" height="8" fill="#e74c3c" opacity="0.9"/>
+  <!-- Run 2 -->
+  <g opacity="0.6">
+    <rect x="725" y="312" width="8" height="16" fill="#7c3aed" opacity="0.7"/>
+    <rect x="735" y="304" width="8" height="24" fill="#7c3aed" opacity="0.6"/>
+    <rect x="745" y="296" width="8" height="32" fill="#7c3aed" opacity="0.5"/>
+    <rect x="755" y="288" width="8" height="40" fill="#7c3aed" opacity="0.4"/>
+    <rect x="765" y="280" width="8" height="48" fill="#7c3aed" opacity="0.35"/>
+    <rect x="775" y="272" width="8" height="56" fill="#7c3aed" opacity="0.3"/>
+    <rect x="785" y="264" width="8" height="64" fill="#7c3aed" opacity="0.25"/>
+  </g>
+  <!-- Reset at CP2 -->
+  <rect x="795" y="320" width="8" height="8" fill="#e74c3c" opacity="0.9"/>
+  <!-- Run 3 -->
+  <g opacity="0.6">
+    <rect x="805" y="312" width="8" height="16" fill="#7c3aed" opacity="0.7"/>
+    <rect x="815" y="304" width="8" height="24" fill="#7c3aed" opacity="0.6"/>
+    <rect x="825" y="296" width="8" height="32" fill="#7c3aed" opacity="0.5"/>
+    <rect x="835" y="288" width="8" height="40" fill="#7c3aed" opacity="0.4"/>
+    <rect x="845" y="280" width="8" height="48" fill="#7c3aed" opacity="0.35"/>
+    <rect x="855" y="272" width="8" height="56" fill="#7c3aed" opacity="0.3"/>
+  </g>
+
+  <text x="717" y="256" text-anchor="middle" font-size="8" fill="#e74c3c" font-weight="bold">reset</text>
+  <text x="797" y="256" text-anchor="middle" font-size="8" fill="#e74c3c" font-weight="bold">reset</text>
+
+  <text x="745" y="348" text-anchor="middle" font-size="9" fill="#333" font-weight="bold">Online • Bayesian • Probabilistic</text>
+
+  <!-- COMPARISON TABLE -->
+  <rect x="15" y="370" width="870" height="145" rx="8" fill="#fff8e1" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="450" y="393" text-anchor="middle" font-size="13" font-weight="bold" fill="#92400e">Method Comparison</text>
+
+  <!-- Headers -->
+  <text x="130" y="415" text-anchor="middle" font-size="10" fill="#555" font-weight="bold">Property</text>
+  <text x="310" y="415" text-anchor="middle" font-size="10" fill="#2c5282" font-weight="bold">CUSUM</text>
+  <text x="530" y="415" text-anchor="middle" font-size="10" fill="#1e7a1e" font-weight="bold">PELT</text>
+  <text x="750" y="415" text-anchor="middle" font-size="10" fill="#5b21b6" font-weight="bold">BOCPD</text>
+
+  <line x1="30" y1="422" x2="870" y2="422" stroke="#ddd" stroke-width="1"/>
+
+  <!-- Row 1 -->
+  <text x="130" y="440" text-anchor="middle" font-size="9" fill="#333">Mode</text>
+  <text x="310" y="440" text-anchor="middle" font-size="9" fill="#333">Online (streaming)</text>
+  <text x="530" y="440" text-anchor="middle" font-size="9" fill="#333">Offline (batch)</text>
+  <text x="750" y="440" text-anchor="middle" font-size="9" fill="#333">Online (streaming)</text>
+
+  <!-- Row 2 -->
+  <text x="130" y="458" text-anchor="middle" font-size="9" fill="#333">Output</text>
+  <text x="310" y="458" text-anchor="middle" font-size="9" fill="#333">Binary alarm</text>
+  <text x="530" y="458" text-anchor="middle" font-size="9" fill="#333">Exact CP locations</text>
+  <text x="750" y="458" text-anchor="middle" font-size="9" fill="#333">P(change) at each t</text>
+
+  <!-- Row 3 -->
+  <text x="130" y="476" text-anchor="middle" font-size="9" fill="#333">Tuning</text>
+  <text x="310" y="476" text-anchor="middle" font-size="9" fill="#333">h (threshold), drift</text>
+  <text x="530" y="476" text-anchor="middle" font-size="9" fill="#333">Penalty (BIC/manual)</text>
+  <text x="750" y="476" text-anchor="middle" font-size="9" fill="#333">Hazard function, prior</text>
+
+  <!-- Row 4 -->
+  <text x="130" y="494" text-anchor="middle" font-size="9" fill="#333">Best for</text>
+  <text x="310" y="494" text-anchor="middle" font-size="9" fill="#333">Real-time mean shifts</text>
+  <text x="530" y="494" text-anchor="middle" font-size="9" fill="#333">Historical segmentation</text>
+  <text x="750" y="494" text-anchor="middle" font-size="9" fill="#333">Uncertainty-aware monitoring</text>
+
+  <!-- Row 5 -->
+  <text x="130" y="510" text-anchor="middle" font-size="9" fill="#333">Python</text>
+  <text x="310" y="510" text-anchor="middle" font-size="9" fill="#333" font-family="monospace">numpy (manual)</text>
+  <text x="530" y="510" text-anchor="middle" font-size="9" fill="#333" font-family="monospace">ruptures</text>
+  <text x="750" y="510" text-anchor="middle" font-size="9" fill="#333" font-family="monospace">bayesian_changepoint</text>
+</svg>

--- a/time-series/anomaly-detection/images/phase4-pca-monitoring.svg
+++ b/time-series/anomaly-detection/images/phase4-pca-monitoring.svg
@@ -1,0 +1,149 @@
+<svg viewBox="0 0 900 520" xmlns="http://www.w3.org/2000/svg" font-family="'Segoe UI', Arial, sans-serif">
+  <text x="450" y="28" text-anchor="middle" font-size="18" font-weight="bold" fill="#1a1a2e">PCA-Based Multivariate Process Monitoring</text>
+
+  <!-- LEFT: PCA Concept -->
+  <rect x="15" y="45" width="280" height="220" rx="8" fill="#f0f4ff" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="155" y="68" text-anchor="middle" font-size="13" font-weight="bold" fill="#2c5282">PCA Projection</text>
+  <text x="155" y="83" text-anchor="middle" font-size="9" fill="#666">n sensors → k principal components (k ≪ n)</text>
+
+  <!-- Scatter plot showing PC1 vs PC2 -->
+  <line x1="45" y1="240" x2="270" y2="240" stroke="#888" stroke-width="1"/>
+  <line x1="45" y1="240" x2="45" y2="95" stroke="#888" stroke-width="1"/>
+  <text x="160" y="257" text-anchor="middle" font-size="9" fill="#666">PC₁</text>
+  <text x="33" y="167" text-anchor="middle" font-size="9" fill="#666" transform="rotate(-90,33,167)">PC₂</text>
+
+  <!-- Normal cluster (ellipse) -->
+  <ellipse cx="145" cy="175" rx="65" ry="40" fill="#4a90d9" opacity="0.08" stroke="#4a90d9" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <text x="145" y="225" text-anchor="middle" font-size="8" fill="#4a90d9">T² confidence ellipse (95%)</text>
+
+  <!-- Normal points -->
+  <g fill="#4a90d9" opacity="0.5">
+    <circle cx="130" cy="170" r="3"/><circle cx="155" cy="180" r="3"/><circle cx="140" cy="160" r="3"/>
+    <circle cx="160" cy="165" r="3"/><circle cx="125" cy="185" r="3"/><circle cx="170" cy="175" r="3"/>
+    <circle cx="135" cy="175" r="3"/><circle cx="150" cy="155" r="3"/><circle cx="165" cy="185" r="3"/>
+    <circle cx="120" cy="172" r="3"/><circle cx="145" cy="190" r="3"/><circle cx="155" cy="168" r="3"/>
+    <circle cx="138" cy="182" r="3"/><circle cx="162" cy="170" r="3"/><circle cx="148" cy="162" r="3"/>
+  </g>
+
+  <!-- Anomaly points outside ellipse -->
+  <circle cx="240" cy="120" r="5" fill="#e74c3c" stroke="#c0392b" stroke-width="1.5"/>
+  <text x="248" y="112" font-size="8" fill="#e74c3c" font-weight="bold">High T²</text>
+  <circle cx="80" cy="105" r="5" fill="#f59e0b" stroke="#d97706" stroke-width="1.5"/>
+  <text x="80" y="97" text-anchor="middle" font-size="8" fill="#d97706" font-weight="bold">High Q</text>
+
+  <!-- CENTER: T² and Q Statistics Over Time -->
+  <rect x="310" y="45" width="575" height="220" rx="8" fill="#fafafa" stroke="#ccc" stroke-width="1"/>
+  <text x="597" y="68" text-anchor="middle" font-size="13" font-weight="bold" fill="#333">Monitoring Statistics Over Time</text>
+
+  <!-- T² chart -->
+  <text x="325" y="90" font-size="10" font-weight="bold" fill="#2c5282">T² (Hotelling's)</text>
+  <text x="325" y="102" font-size="8" fill="#666">Distance in PC subspace</text>
+  <line x1="330" y1="150" x2="860" y2="150" stroke="#888" stroke-width="0.5"/>
+  <line x1="330" y1="150" x2="330" y2="90" stroke="#888" stroke-width="0.5"/>
+
+  <!-- T² signal - mostly low, spike in anomaly region -->
+  <polyline points="340,142 360,140 380,144 400,138 420,142 440,140 460,143 480,139 500,141 520,140 540,142 560,138 580,143 600,140 620,142 640,138 660,115 680,100 700,92 720,105 740,110 760,140 780,143 800,139 820,141 840,140" fill="none" stroke="#2c5282" stroke-width="1.8"/>
+
+  <!-- T² threshold -->
+  <line x1="330" y1="118" x2="860" y2="118" stroke="#e74c3c" stroke-width="1" stroke-dasharray="5,3"/>
+  <text x="862" y="116" font-size="8" fill="#e74c3c">T²α</text>
+
+  <!-- Anomaly region -->
+  <rect x="655" y="85" width="90" height="70" rx="3" fill="#e74c3c" opacity="0.06"/>
+
+  <!-- Q chart -->
+  <text x="325" y="180" font-size="10" font-weight="bold" fill="#7c3aed">Q / SPE</text>
+  <text x="325" y="192" font-size="8" fill="#666">Residual (off-model) distance</text>
+  <line x1="330" y1="248" x2="860" y2="248" stroke="#888" stroke-width="0.5"/>
+  <line x1="330" y1="248" x2="330" y2="185" stroke="#888" stroke-width="0.5"/>
+
+  <!-- Q signal -->
+  <polyline points="340,240 360,238 380,242 400,236 420,240 440,238 460,241 480,237 500,239 520,238 540,240 560,237 580,241 600,238 620,240 640,236 660,220 680,208 700,195 720,200 740,212 760,238 780,241 800,237 820,239 840,238" fill="none" stroke="#7c3aed" stroke-width="1.8"/>
+
+  <!-- Q threshold -->
+  <line x1="330" y1="215" x2="860" y2="215" stroke="#e74c3c" stroke-width="1" stroke-dasharray="5,3"/>
+  <text x="862" y="213" font-size="8" fill="#e74c3c">Qα</text>
+
+  <!-- Anomaly region on Q chart -->
+  <rect x="655" y="185" width="90" height="68" rx="3" fill="#e74c3c" opacity="0.06"/>
+
+  <!-- Anomaly label spanning both -->
+  <text x="700" y="82" text-anchor="middle" font-size="9" fill="#c0392b" font-weight="bold">ANOMALY</text>
+
+  <!-- BOTTOM: Interpretation Guide -->
+  <rect x="15" y="280" width="425" height="120" rx="8" fill="#e8fde8" stroke="#27ae60" stroke-width="1.5"/>
+  <text x="227" y="303" text-anchor="middle" font-size="12" font-weight="bold" fill="#1e7a1e">Interpreting T² vs Q</text>
+
+  <text x="35" y="325" font-size="10" fill="#333">High T², normal Q:</text>
+  <text x="195" y="325" font-size="9" fill="#555">unusual but within learned correlations</text>
+  <text x="35" y="345" font-size="10" fill="#333">Normal T², high Q:</text>
+  <text x="195" y="345" font-size="9" fill="#555">correlation structure has broken down</text>
+  <text x="35" y="365" font-size="10" fill="#333">Both high:</text>
+  <text x="195" y="365" font-size="9" fill="#555">large deviation + broken correlations</text>
+  <text x="35" y="387" font-size="9" fill="#666" font-style="italic">Q often more actionable: "something new is happening"</text>
+
+  <!-- Contribution Plot -->
+  <rect x="455" y="280" width="430" height="120" rx="8" fill="#fff8e1" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="670" y="303" text-anchor="middle" font-size="12" font-weight="bold" fill="#92400e">Contribution Plot (Root Cause)</text>
+  <text x="670" y="316" text-anchor="middle" font-size="9" fill="#666">Which sensor is driving the anomaly?</text>
+
+  <!-- Bar chart of contributions -->
+  <line x1="475" y1="385" x2="860" y2="385" stroke="#888" stroke-width="1"/>
+  
+  <rect x="490" y="360" width="35" height="25" fill="#4a90d9" opacity="0.4"/>
+  <text x="507" y="397" text-anchor="middle" font-size="8" fill="#555">T₁</text>
+
+  <rect x="540" y="340" width="35" height="45" fill="#e74c3c" opacity="0.8"/>
+  <text x="557" y="397" text-anchor="middle" font-size="8" fill="#e74c3c" font-weight="bold">P₁</text>
+
+  <rect x="590" y="365" width="35" height="20" fill="#4a90d9" opacity="0.4"/>
+  <text x="607" y="397" text-anchor="middle" font-size="8" fill="#555">F₁</text>
+
+  <rect x="640" y="370" width="35" height="15" fill="#4a90d9" opacity="0.4"/>
+  <text x="657" y="397" text-anchor="middle" font-size="8" fill="#555">T₂</text>
+
+  <rect x="690" y="330" width="35" height="55" fill="#e74c3c" opacity="0.8"/>
+  <text x="707" y="397" text-anchor="middle" font-size="8" fill="#e74c3c" font-weight="bold">P₂</text>
+
+  <rect x="740" y="368" width="35" height="17" fill="#4a90d9" opacity="0.4"/>
+  <text x="757" y="397" text-anchor="middle" font-size="8" fill="#555">F₂</text>
+
+  <rect x="790" y="362" width="35" height="23" fill="#4a90d9" opacity="0.4"/>
+  <text x="807" y="397" text-anchor="middle" font-size="8" fill="#555">L₁</text>
+
+  <!-- Highlight top contributors -->
+  <text x="625" y="328" text-anchor="middle" font-size="9" fill="#c0392b" font-weight="bold">← P₁ and P₂ are top contributors</text>
+
+  <!-- Bottom: Key Workflow -->
+  <rect x="15" y="415" width="870" height="90" rx="8" fill="#f5f0ff" stroke="#7c3aed" stroke-width="1.5"/>
+  <text x="450" y="438" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">PCA Monitoring Workflow</text>
+
+  <!-- Flow arrows -->
+  <rect x="35" y="450" width="140" height="40" rx="6" fill="white" stroke="#7c3aed" stroke-width="1"/>
+  <text x="105" y="465" text-anchor="middle" font-size="9" fill="#333" font-weight="bold">1. Fit PCA</text>
+  <text x="105" y="478" text-anchor="middle" font-size="8" fill="#666">on normal training data</text>
+
+  <text x="190" y="472" font-size="14" fill="#7c3aed">→</text>
+
+  <rect x="205" y="450" width="140" height="40" rx="6" fill="white" stroke="#7c3aed" stroke-width="1"/>
+  <text x="275" y="465" text-anchor="middle" font-size="9" fill="#333" font-weight="bold">2. Set Thresholds</text>
+  <text x="275" y="478" text-anchor="middle" font-size="8" fill="#666">T²α, Qα from χ² or F dist</text>
+
+  <text x="360" y="472" font-size="14" fill="#7c3aed">→</text>
+
+  <rect x="375" y="450" width="140" height="40" rx="6" fill="white" stroke="#7c3aed" stroke-width="1"/>
+  <text x="445" y="465" text-anchor="middle" font-size="9" fill="#333" font-weight="bold">3. Project New Data</text>
+  <text x="445" y="478" text-anchor="middle" font-size="8" fill="#666">compute T², Q per sample</text>
+
+  <text x="530" y="472" font-size="14" fill="#7c3aed">→</text>
+
+  <rect x="545" y="450" width="140" height="40" rx="6" fill="white" stroke="#7c3aed" stroke-width="1"/>
+  <text x="615" y="465" text-anchor="middle" font-size="9" fill="#333" font-weight="bold">4. Flag + Diagnose</text>
+  <text x="615" y="478" text-anchor="middle" font-size="8" fill="#666">contribution plots</text>
+
+  <text x="700" y="472" font-size="14" fill="#7c3aed">→</text>
+
+  <rect x="715" y="450" width="155" height="40" rx="6" fill="white" stroke="#7c3aed" stroke-width="1"/>
+  <text x="792" y="465" text-anchor="middle" font-size="9" fill="#333" font-weight="bold">5. Operator Action</text>
+  <text x="792" y="478" text-anchor="middle" font-size="8" fill="#666">"check pressure on unit X"</text>
+</svg>

--- a/time-series/anomaly-detection/timeseries-anomaly-detection-guide.md
+++ b/time-series/anomaly-detection/timeseries-anomaly-detection-guide.md
@@ -1,0 +1,1034 @@
+# Time-Series Analysis & Anomaly Detection for Industrial Processes
+
+## Estimated Reading Time: 3–4 hours
+
+This guide is structured for someone with deep learning and gradient boosting experience who needs to build working knowledge of time-series analysis and anomaly detection for industrial process data (refinery, ammonia, olefins plants). Each concept is compressed to its core intuition, practical implications, and failure modes.
+
+---
+
+# Phase 1: Time-Series Foundations
+
+## 1.1 What Makes Time-Series Data Structurally Different
+
+In tabular ML (XGBoost on process features, image classification), rows are assumed **independent and identically distributed (\(\text{i.i.d.}\))**. Shuffling rows doesn't change the problem. In time-series data, **the order is the information**. A reactor temperature of \(412\,^{\circ}\mathrm{C}\) means something completely different depending on whether it was \(405\,^{\circ}\mathrm{C}\) or \(420\,^{\circ}\mathrm{C}\) five minutes ago.
+
+**Key intuition:** Every observation carries an invisible context — its recent past. Destroying that context (shuffling, naive train/test splits) destroys the signal you're trying to model.
+
+**Practical implications:**
+- You cannot do random train/test splits. You must use temporal splits (walk-forward validation), exactly as you would avoid data leakage in sequential recommendation systems.
+- Feature engineering must respect causality: you can only use past values to predict/evaluate the present. A centered moving average uses future data — fine for decomposition, fatal for prediction.
+- Adjacent observations are correlated. This means standard error estimates (confidence intervals, \(p\)-values) from \(\text{i.i.d.}\) assumptions are wrong — they'll be too narrow, making you overconfident.
+
+**Common failure modes:**
+- Using `sklearn.model_selection.KFold` instead of `TimeSeriesSplit` — this leaks future information into training.
+- Computing rolling features using `center=True` in pandas during model training.
+- Reporting model accuracy on randomly held-out points rather than a forward time period.
+
+---
+
+## 1.2 Stationarity
+
+A time series is **stationary** if its statistical properties (mean, variance, autocorrelation structure) do not change over time. Not that the values are constant — that the *rules generating the values* are constant.
+
+**Analogy from deep learning:** Stationarity is the time-series equivalent of the assumption that training and test data come from the same distribution. A non-stationary series is like having distribution shift baked into your dataset — the patterns you learn from January may not apply in June.
+
+**Why it matters:** Almost every classical time-series model (ARIMA, exponential smoothing, spectral analysis) assumes stationarity or can only handle specific types of non-stationarity (like a linear trend). If you fit an AR model to a non-stationary series, the estimated coefficients are meaningless — this is called "spurious regression."
+
+**Two standard tests:**
+
+| Test | Null Hypothesis | Use When |
+|------|----------------|----------|
+| **ADF (Augmented Dickey-Fuller)** | Series has a unit root (non-stationary) | You suspect a trend or random walk. Reject → evidence of stationarity. |
+| **KPSS** | Series is stationary | Confirmatory test. Reject → evidence of non-stationarity. |
+
+Use both together. If ADF rejects and KPSS doesn't reject, you have strong evidence of stationarity. If they disagree, you likely have trend-stationarity (stationary after removing a deterministic trend) or need differencing.
+
+**Industrial example:** A heat exchanger's outlet temperature may show a slow upward drift over months as fouling builds up. The raw signal is non-stationary (rising mean). But the *deviation from expected fouling trend* might be stationary — and that's where you'd look for anomalies.
+
+**Making a series stationary:**
+- **Differencing:** Replace $y_t$ with $y_t - y_{t-1}$. Removes trends. Apply twice for quadratic trends.
+- **Log transform:** Stabilizes variance when it grows with the level (e.g., flow rates that become noisier at higher throughput).
+- **Seasonal differencing:** $y_t - y_{t-s}$ where $s$ is the seasonal period.
+
+**Common failure modes:**
+- Over-differencing: applying $d=2$ when $d=1$ suffices. This introduces artificial negative autocorrelation and makes modeling harder.
+- Ignoring regime-dependent stationarity: a column that's stationary during steady-state operation but non-stationary across startup/shutdown transitions. You need regime segmentation before stationarity testing.
+- Treating ADF/KPSS as definitive. They have low power on short series and can't detect all forms of non-stationarity (e.g., changing variance).
+
+---
+
+## 1.3 Autocorrelation and Partial Autocorrelation
+
+**Autocorrelation (ACF)** measures the correlation between a time series and lagged copies of itself. ACF at lag $k$ answers: "How correlated is today's value with the value $k$ steps ago?"
+
+**Partial autocorrelation (PACF)** measures the *direct* correlation at lag $k$ after removing the influence of all shorter lags. It isolates the unique contribution of lag $k$.
+
+**Analogy:** Think of ACF like total feature importance in a gradient-boosted model — feature 5 might look important because it's correlated with feature 3, which is the real driver. PACF is like SHAP values or permutation importance — it shows the *direct* effect after controlling for everything else.
+
+![Diagram: ACF and PACF signature patterns](images/phase1-acf-pacf-signatures.svg)
+*Diagram should show: Four panels — (1) ACF of an AR(1) process showing exponential decay, (2) PACF of the same AR(1) showing a single significant spike at lag 1, (3) ACF of an MA(1) process showing a single spike at lag 1 then cutting to zero, (4) PACF of the same MA(1) showing exponential decay. Each panel should have lag on x-axis, correlation on y-axis, and blue significance bands. Label the signature pattern for each.*
+
+**Reading ACF/PACF — the diagnostic signatures:**
+
+| Pattern | ACF | PACF | Interpretation |
+|---------|-----|------|----------------|
+| AR(p) process | Tails off (exponential/oscillating decay) | Cuts off after lag p | The process has direct memory of the last p values |
+| MA(q) process | Cuts off after lag q | Tails off | The process is driven by the last q random shocks |
+| ARMA(p,q) | Both tail off | Both tail off | Mixed — use information criteria to select orders |
+| Non-stationary | ACF decays very slowly | Large spike at lag 1 | Needs differencing before modeling |
+
+**Industrial example:** A pressure sensor in a distillation column typically shows strong AR behavior — current pressure depends directly on pressure a few time steps ago because of the physical inertia of the system. A flow controller responding to setpoint changes might show MA behavior — the controller applies corrections (shocks), and the effect persists for a few steps.
+
+**Practical implication:** ACF/PACF are your first diagnostic tool when examining any process tag. Before fitting any model, plot these. They tell you what kind of model the data wants.
+
+**Common failure modes:**
+- Computing ACF on non-stationary data — you'll see slow decay that tells you nothing about the autocorrelation structure, only that you forgot to difference.
+- Ignoring seasonal lags. In a plant with 24-hour operating cycles, check lag 1440 (at 1-minute sampling) or lag 48 (at 30-minute sampling). The ACF at seasonal lags reveals periodic patterns.
+- Using too few lags. For historian data at 1-minute resolution, check at least a few hours of lags, and also check around known operational cycles.
+
+---
+
+## 1.4 Trend, Seasonality, and Residual Decomposition
+
+Any time series can be decomposed into three components:
+
+$$y_t = T_t + S_t + R_t \quad \text{(additive)}$$
+$$y_t = T_t \times S_t \times R_t \quad \text{(multiplicative)}$$
+
+- **Trend ($T_t$):** Long-term direction. In process data: catalyst deactivation causing slowly declining conversion, fouling causing gradually rising pressure drop.
+- **Seasonality ($S_t$):** Repeating patterns at known periods. In process data: day/night ambient temperature cycling affecting cooling water temperature, weekly production schedule changes, seasonal feed quality variation.
+- **Residual ($R_t$):** What's left after removing trend and seasonality. This is where anomalies live — and also where your model's signal is.
+
+**Additive vs. multiplicative:** Use multiplicative when the seasonal swing grows proportionally with the level. If a heat exchanger shows \(\pm 2\,^{\circ}\mathrm{C}\) daily swings at \(200\,^{\circ}\mathrm{C}\) and \(\pm 4\,^{\circ}\mathrm{C}\) swings at \(400\,^{\circ}\mathrm{C}\), that's multiplicative. If the swing is always \(\pm 2\,^{\circ}\mathrm{C}\) regardless of level, that's additive.
+
+**Two decomposition approaches:**
+
+1. **Classical decomposition** (`statsmodels.tsa.seasonal.seasonal_decompose`): Uses moving averages. Simple, interpretable, but assumes fixed seasonal pattern. Fine for initial exploration.
+2. **STL decomposition** (`statsmodels.tsa.seasonal.STL`): Uses LOESS (locally weighted regression) to allow the seasonal pattern and trend to evolve over time. Strongly preferred for real data.
+
+**Key intuition:** Decomposition is not a model — it's a diagnostic. It helps you *see* what's happening. The residual component is particularly valuable: if your residuals still show structure (autocorrelation, patterns), your decomposition missed something.
+
+**Industrial example:** A cooling tower outlet temperature decomposes cleanly: rising trend (fouling), daily seasonality (ambient temperature), and residuals. An anomaly in the residuals — a sudden jump not explained by trend or season — might indicate a fan failure or basin level problem.
+
+**Common failure modes:**
+- Using classical decomposition on data with changing seasonal amplitude — it will bleed seasonal variation into the residuals.
+- Decomposing data that spans shutdowns without masking them first. A shutdown creates a massive artificial "trend change" that corrupts the entire decomposition.
+- Choosing the wrong seasonal period. STL requires you to specify the period. Getting it wrong makes the decomposition meaningless. Use ACF or domain knowledge to identify the correct period.
+
+---
+
+## 1.5 The Spectral View: Frequency Content and Aliasing
+
+Every time series can be represented as a sum of sine waves at different frequencies. The **power spectral density (PSD)** shows how much variance (energy) exists at each frequency.
+
+**Analogy from deep learning:** If the time domain is like looking at pixel values directly, the frequency domain is like looking at the Fourier transform of an image. High-frequency components = fast oscillations (noise, vibration). Low-frequency components = slow drifts (fouling, catalyst deactivation). Just as CNNs implicitly learn frequency filters, understanding the spectral content tells you what temporal scales carry information.
+
+![Diagram: Time domain vs frequency domain view](images/phase1-spectral-view.svg)
+*Diagram should show: Left panel — a time series composed of a slow drift plus a 24-hour cycle plus high-frequency noise. Right panel — the PSD (power vs frequency or period) showing three distinct peaks corresponding to each component. Arrow annotations connecting each peak to the corresponding pattern in the time domain. X-axis of PSD labeled in both frequency (Hz) and period (hours) for intuition.*
+
+**Why this matters for industrial data:**
+
+1. **Identifying dominant periods:** A PSD peak at 24 hours confirms ambient-driven cycling. A peak at 8 hours might reveal shift-change effects. Unexpected peaks at specific frequencies can indicate mechanical problems (e.g., a compressor at its rotation frequency).
+2. **Separating signal from noise:** If your signal of interest is at low frequencies (slow fouling) and noise is at high frequencies (sensor jitter), a low-pass filter cleanly separates them. Without spectral understanding, you're guessing at filter parameters.
+3. **Detecting oscillating control loops:** A valve hunting between open and closed creates a characteristic spectral signature — a peak at the oscillation frequency. This is one of the most valuable uses of spectral analysis in process control.
+
+**Aliasing — the critical sampling constraint:**
+
+The **Nyquist theorem** says you can only reliably detect frequencies below half your sampling rate \(f_s\): you can estimate frequencies in \([0,\, f_s / 2)\) (Nyquist frequency \(f_{\mathrm{Nyq}} = f_s / 2\)). At 1-minute sampling (\(f_s = 1/60\,\mathrm{Hz}\)), \(f_{\mathrm{Nyq}} = 1/120\,\mathrm{Hz}\) — oscillations faster than once per 2 minutes will "alias" (appear as false lower-frequency signals).
+
+**Industrial consequence:** If a compressor vibrates at \(50\,\mathrm{Hz}\) but you sample at \(f_s = 1/60\,\mathrm{Hz}\), you will *not* see the vibration. Worse, you might see a ghost signal at a completely wrong frequency. Historian data at 30s–1min resolution is adequate for process dynamics (things that change over minutes to hours) but cannot capture mechanical vibration or fast electrical transients.
+
+**Practical tools:**
+- `scipy.signal.welch` — estimates PSD using Welch's method (averaged periodograms). More stable than a raw FFT.
+- `scipy.signal.spectrogram` — shows how frequency content changes over time (a time-frequency representation). Essential when the dominant frequencies shift — e.g., a compressor speeding up.
+
+**Common failure modes:**
+- Applying FFT to non-stationary data without windowing or detrending — the trend creates a massive low-frequency spike that drowns out everything else.
+- Ignoring aliasing when combining data from different sampling rates (e.g., 1-second DCS data merged with 1-minute historian data).
+- Over-interpreting spectral peaks. A peak at a 24-hour period could be ambient temperature, shift changes, or daily lab adjustments. Spectral analysis tells you *what* frequencies exist, not *why*.
+
+---
+
+## 1.6 Process Dynamics vs. Measurement Noise
+
+Every sensor reading in a plant is the sum of two things. With observation \(y_t\), latent process value \(x_t\), and measurement noise \(\varepsilon_t\):
+
+$$y_t = x_t + \varepsilon_t$$
+
+**Process dynamics** are the real physical changes — temperature rising because heat input increased, pressure dropping because a valve opened. **Measurement noise** is everything the sensor adds — electrical interference, quantization, calibration drift, thermocouple aging.
+
+**Why this distinction matters for anomaly detection:** You need to detect anomalies in the *process*, not in the *sensor*. A noisy thermocouple that occasionally spikes by \(\pm 5\,^{\circ}\mathrm{C}\) is a measurement artifact, not a process anomaly. Conversely, a slow \(2\,^{\circ}\mathrm{C}\) drift over a week that's well within sensor noise could indicate real fouling.
+
+**How to tell them apart:**
+
+| Characteristic | Process dynamics | Measurement noise |
+|---------------|-----------------|-------------------|
+| Temporal structure | Autocorrelated (smooth, physics-driven) | Usually white (uncorrelated) or pink |
+| Cross-correlation | Affects related tags (temp rise → pressure rise) | Affects only the noisy sensor |
+| Spectral signature | Concentrated at low/mid frequencies | Flat or concentrated at high frequencies |
+| Response to filtering | Signal preserved | Signal removed |
+
+**Industrial example:** A reactor temperature tag shows \(0.5\,^{\circ}\mathrm{C}\) random jitter at 1-minute resolution (noise floor of the thermocouple) plus a true process change of \(3\,^{\circ}\mathrm{C}/\mathrm{h}\) due to catalyst deactivation. A simple moving average filter separates these because they live at different frequency scales.
+
+**Practical implication:** Before running anomaly detection on any tag, understand its noise floor. A \(0.1\,^{\circ}\mathrm{C}\) change on a thermocouple with \(0.5\,^{\circ}\mathrm{C}\) noise is undetectable. The same \(0.1\,^{\circ}\mathrm{C}\) change on a high-precision RTD with \(0.01\,^{\circ}\mathrm{C}\) noise is a clear signal.
+
+**Key tools:**
+- **Allan variance / overlapping Allan deviation:** Characterizes noise as a function of averaging time. Standard in metrology, underused in process data.
+- **Cross-correlation:** If a spike appears in one temperature tag but not in physically adjacent tags, it's likely measurement noise, not a real event.
+- **Redundant sensors:** Many critical measurements have 2-of-3 or median-select configurations. Comparing redundant sensors directly isolates measurement noise.
+
+---
+
+## 1.7 Resampling, Alignment, and Handling Irregular Timestamps
+
+Historian systems (PI, IP.21, Honeywell PHD) do not store data at perfectly regular intervals. They use **compression algorithms** (typically swinging-door compression) that only record a new value when the signal changes by more than a deadband threshold. This means:
+
+- Data arrives at **irregular intervals** — a stable signal might have one point per hour; a changing signal might have points every second.
+- **Missing data doesn't mean the sensor failed** — it means the value didn't change enough to trigger a new recording.
+- Different tags have different compression settings, so timestamps across tags are **not aligned**.
+
+![Diagram: Historian compression and alignment](images/phase1-historian-alignment.svg)
+*Diagram should show: Top — a true continuous signal with dots showing where the historian recorded points (clustered during changes, sparse during flat periods). Middle — the same signal reconstructed with step interpolation (last-known-value) showing the staircase effect. Bottom — two tags on different timelines being aligned to a common 1-minute grid, with arrows showing interpolation points. Highlight the difference between step interpolation (correct for most process data) and linear interpolation (appropriate for smoothly varying signals like temperature).*
+
+**Alignment strategy for multi-tag analysis:**
+
+1. **Choose a common time grid** — typically the coarsest resolution you need (e.g., 1-minute intervals).
+2. **Decide interpolation method per tag:**
+   - **Step (forward-fill):** Appropriate for discrete states (valve positions, on/off signals, setpoints). The value *is* the last known value until it explicitly changes.
+   - **Linear interpolation:** Appropriate for continuously varying signals (temperature, pressure, flow) that change smoothly.
+   - **No interpolation (NaN):** When gaps are too large to interpolate reliably. Define a maximum gap threshold per tag.
+3. **Resample:** Use `pandas.DataFrame.resample()` with appropriate aggregation (mean, last, max — depending on the tag's semantics).
+
+**Critical implementation details:**
+
+- **Beware of interpolating across shutdowns.** If a sensor reads \(400\,^{\circ}\mathrm{C}\) before shutdown and \(25\,^{\circ}\mathrm{C}\) after, linear interpolation creates phantom readings at \(300\,^{\circ}\mathrm{C}\), \(200\,^{\circ}\mathrm{C}\), etc. Mask shutdown periods before interpolation.
+- **Timestamps may not be in UTC.** Historian systems often store in local time. Daylight saving time transitions create duplicate or missing timestamps. Always convert to UTC for analysis, convert back for display.
+- **Aggregation matters.** A 1-minute mean of a flow rate is physically meaningful (average flow). A 1-minute mean of a valve position (0 or 100%) can be meaningless — you might want "percent time open" instead.
+
+**Common failure modes:**
+- Forward-filling across multi-hour gaps and treating the result as real data. Define max-gap rules.
+- Using linear interpolation for digital/discrete signals.
+- Ignoring that compression settings differ between tags — one tag might have \(1\%\) deadband, another \(5\%\), making their effective resolutions very different.
+- Merging historian exports without checking timezone consistency.
+
+---
+
+*End of Phase 1. Key takeaway: Before modeling anything, you need to understand the temporal structure (ACF/PACF), confirm or establish stationarity, separate signal from noise, and align your historian data onto a clean, consistent time grid. Every subsequent method assumes you've done this groundwork.*
+
+# Phase 2: Classical and Statistical Time-Series Methods
+
+## 2.1 Exponential Smoothing
+
+Exponential smoothing produces forecasts by computing weighted averages of past observations, where the weights decay exponentially as observations get older. Recent values matter more than distant ones.
+
+**The core idea:** Your best estimate of the next value is a blend of what you just observed and what you previously predicted:
+
+$$\hat{y}_{t+1} = \alpha \cdot y_t + (1 - \alpha) \cdot \hat{y}_t$$
+
+where $\alpha \in (0, 1)$ controls how fast old observations are forgotten. High $\alpha$ = reactive (tracks changes quickly, noisy). Low $\alpha$ = smooth (slow to respond, filters noise).
+
+**Analogy:** This is an exponential moving average (EMA) — you've likely used it in training loss curves. The smoothing parameter $\alpha$ is analogous to momentum in SGD: high momentum (low $\alpha$) gives a smoother trajectory but responds slowly to sudden changes.
+
+**Three variants, each adding a component:**
+
+| Variant | Captures | Use When |
+|---------|----------|----------|
+| **Simple (SES)** | Level only | No trend, no seasonality. Stationary-ish process fluctuating around a slowly changing mean. |
+| **Double (Holt)** | Level + trend | Signal has a drift direction. Catalyst deactivation showing declining conversion over weeks. |
+| **Triple (Holt-Winters)** | Level + trend + seasonality | Signal has periodic patterns. Cooling water temperature with daily ambient cycling. |
+
+**Industrial examples:**
+- **SES:** Smoothing a noisy pH measurement for real-time display. The operator wants to see the underlying value, not the sensor jitter.
+- **Holt:** Tracking the declining efficiency of a heat exchanger as fouling progresses — the trend component captures the degradation rate.
+- **Holt-Winters (additive):** Modeling a column's reflux rate that has a daily cycle driven by ambient temperature, plus a gradual upward trend as feed composition shifts seasonally.
+
+**Practical implications:**
+- Exponential smoothing is often the *right* model for operational dashboards where you need a smooth "current state" estimate.
+- The Holt-Winters forecast residuals are a useful baseline anomaly detector: if the residual exceeds a threshold, something changed that the smooth trend+season model didn't expect.
+- `statsmodels.tsa.holtwinters.ExponentialSmoothing` fits these models and optimizes the smoothing parameters automatically.
+
+**Common failure modes:**
+- Applying SES to data with a clear trend — the forecast perpetually lags behind the true value.
+- Using additive Holt-Winters when seasonal amplitude grows with the level (need multiplicative).
+- Trusting the forecast far into the future. Exponential smoothing forecasts flatten out quickly — the trend component projects linearly forever, which is physically unrealistic. Use for short-term forecasting only (hours to days for process data).
+
+---
+
+## 2.2 ARIMA Family: Modeling Autocorrelation Structure
+
+ARIMA (AutoRegressive Integrated Moving Average) is a family of models that explicitly captures the autocorrelation structure you identified with ACF/PACF in Phase 1.
+
+**Building blocks:**
+
+**AR(p) — AutoRegressive of order p:**
+$$y_t = c + \phi_1 y_{t-1} + \phi_2 y_{t-2} + \cdots + \phi_p y_{t-p} + \varepsilon_t$$
+The current value is a linear combination of the last $p$ values plus white noise. This models *inertia* — physical systems where the current state depends on recent states.
+
+**Analogy:** AR is a linear recurrence relation. If you've worked with RNNs, AR(p) is like a linear RNN with a fixed lookback of $p$ steps and no hidden state nonlinearity.
+
+**MA(q) — Moving Average of order q:**
+$$y_t = c + \varepsilon_t + \theta_1 \varepsilon_{t-1} + \theta_2 \varepsilon_{t-2} + \cdots + \theta_q \varepsilon_{t-q}$$
+The current value depends on the last $q$ random shocks (forecast errors). This models *short-lived disturbances* — a feed composition blip that affects the column for a few time steps then dissipates.
+
+**Note:** "Moving Average" here is unrelated to the rolling-mean moving average. It's about the dependence on past *errors*, not past *values*.
+
+**ARIMA(p, d, q):** Combines AR and MA after differencing $d$ times to achieve stationarity.
+- $p$: number of autoregressive terms (lags of $y$)
+- $d$: number of differences needed for stationarity
+- $q$: number of moving average terms (lags of $\varepsilon$)
+
+**SARIMA(p, d, q)(P, D, Q, s):** Adds seasonal AR, differencing, and MA at seasonal period $s$.
+
+![Diagram: ARIMA model selection workflow](images/phase2-arima-selection.svg)
+*Diagram should show: A flowchart starting with "Raw series" → "Plot & check stationarity (ADF/KPSS)" → branch: if non-stationary → "Difference (d times)" → re-test. If stationary → "Plot ACF/PACF" → decision tree: ACF cuts off at q → MA(q); PACF cuts off at p → AR(p); both tail off → ARMA, use AIC/BIC. Then: "Check residuals" → branch: if residuals are white noise → "Model adequate"; if residuals show structure → "Increase order or add seasonal terms." Side note: "auto_arima (pmdarima) automates this search."*
+
+**Model identification workflow:**
+1. Make the series stationary (determine $d$ and $D$).
+2. Plot ACF/PACF of the differenced series.
+3. Read the signatures (see Phase 1.3 table) to get candidate $p$ and $q$.
+4. Fit candidate models and compare using **AIC** (Akaike Information Criterion) or **BIC** (Bayesian Information Criterion). Lower is better. BIC penalizes complexity more heavily.
+5. Check residuals: they should be white noise (no remaining autocorrelation). Use `statsmodels` `plot_diagnostics()` or the Ljung-Box test.
+
+**Practical shortcut:** `pmdarima.auto_arima()` automates the search over $(p, d, q)$ using information criteria. Use it as a starting point, but always inspect the residual diagnostics.
+
+**Industrial example:** A distillation column's tray temperature, after removing the trend from slowly changing feed composition, might be well-described by AR(2) — the current temperature depends on the last two readings due to thermal inertia and the column's response dynamics. The residuals from this AR(2) model become your "innovation" series — unexpected deviations that might signal tray flooding, weeping, or a control malfunction.
+
+**Common failure modes:**
+- Selecting model order by minimizing training error instead of AIC/BIC — this overfits.
+- Using `auto_arima` without inspecting residuals. It can converge on a local minimum in the search space.
+- Fitting ARIMA to multi-regime data without segmentation. The model averages across regimes, fitting none of them well.
+- Ignoring that ARIMA is a *linear* model. Nonlinear process dynamics (e.g., reactor runaway kinetics) require different approaches.
+
+---
+
+## 2.3 State-Space Models and the Kalman Filter
+
+A state-space model separates the *hidden true state* of a system from the *noisy observations* you get from sensors. It consists of two equations:
+
+**State equation (how the hidden state evolves):**
+$$x_{t} = A \cdot x_{t-1} + B \cdot u_t + w_t$$
+
+**Observation equation (how you measure the state):**
+$$y_t = C \cdot x_t + v_t$$
+
+where $x_t$ is the hidden state, $y_t$ is what the sensor reports, $u_t$ are known inputs (setpoint changes, valve positions), $w_t$ is process noise, and $v_t$ is measurement noise.
+
+**Analogy from deep learning:** This is structurally identical to a latent variable model. The state equation is the "generative model" (how the latent state evolves), and the observation equation is the "decoder" (how latent states map to observations). The Kalman filter is the exact inference algorithm for this model when everything is linear and Gaussian — it's computing the posterior $p(x_t | y_{1:t})$.
+
+**The Kalman filter does two things:**
+1. **Predict:** Use the state equation to forecast where the hidden state should be.
+2. **Update:** When a new observation arrives, blend the prediction with the observation. The **Kalman gain** determines the blend ratio — it's large when you trust the observation (low sensor noise) and small when you trust the prediction (low process noise).
+
+![Diagram: Kalman filter predict-update cycle](images/phase2-kalman-cycle.svg)
+*Diagram should show: A circular diagram with two phases. "Predict" phase: prior state estimate + state model → predicted state + predicted uncertainty (uncertainty grows). "Update" phase: predicted state + new measurement → corrected state + reduced uncertainty. Show the Kalman gain as the knob controlling how much the measurement pulls the estimate. Include a small sidebar showing: high sensor noise → small Kalman gain → trust prediction; low sensor noise → large Kalman gain → trust measurement.*
+
+**Why this matters for industrial processes:**
+- **Sensor fusion:** If you have three temperature sensors on the same pipe, the Kalman filter optimally combines them, weighting each by its reliability.
+- **Missing data handling:** During the predict step, the filter propagates forward even without a new measurement. This naturally handles historian gaps.
+- **Anomaly detection through innovation:** The difference between predicted and observed ($y_t - C \cdot \hat{x}_t$) is called the **innovation**. In a well-tuned Kalman filter, innovations should be white noise. Large innovations mean something unexpected happened — either a process anomaly or a sensor fault.
+- **Tracking dynamics:** The Kalman filter explicitly models how fast a process changes vs. how noisy the sensors are. This is exactly the "process dynamics vs. measurement noise" distinction from Phase 1.6.
+
+**Connection to ARIMA:** Every ARIMA model can be written in state-space form. The Kalman filter is the general framework; ARIMA is a special case. `statsmodels.tsa.statespace` exposes this — you can fit ARIMA models via the Kalman filter and get the innovation sequence for free.
+
+**Industrial example:** A compressor discharge temperature measured by a thermocouple (noisy, \(2\,^{\circ}\mathrm{C}\) standard deviation) can be modeled with a state-space model where the hidden state is the true gas temperature. The Kalman filter provides a smooth estimate of the true temperature and flags when the innovation is unusually large — indicating either a process upset or a failing sensor.
+
+**Common failure modes:**
+- Mis-specifying the process noise vs. measurement noise ratio ($Q/R$). Too little process noise → the filter is sluggish and misses real changes. Too much process noise → the filter is jittery and just tracks the noisy sensor.
+- Assuming linearity when the process is nonlinear (e.g., reaction kinetics, phase transitions). Use the Extended Kalman Filter (EKF) or Unscented Kalman Filter (UKF) for mild nonlinearity, or particle filters for severe nonlinearity.
+- Using the Kalman filter without validating that innovations are actually white noise. Structured innovations mean your state model is wrong.
+
+---
+
+## 2.4 When Classical Methods Beat ML (and When They Don't)
+
+This is a judgment call you'll make constantly. Here's the decision framework:
+
+**Classical methods (exponential smoothing, ARIMA, Kalman filter) win when:**
+- You have a **single tag** or a small number of related tags.
+- The process is approximately **linear**.
+- You need **interpretable parameters** (the AR coefficient tells you the process time constant; the seasonal period tells you the driving cycle).
+- You have **short history** (weeks, not years) — classical models have far fewer parameters to estimate.
+- You need a **credible uncertainty estimate** — classical models produce prediction intervals with known statistical properties.
+- You're building a **baseline** — and you should always have one.
+
+**ML methods (gradient boosting, LSTMs, Transformers) win when:**
+- You have **many tags** with complex nonlinear interactions (multivariate problems).
+- The relationship between inputs and output is **nonlinear** (reaction kinetics, multiphase flow).
+- You have **abundant data** (years of history) to support the parameter count.
+- You can engineer **rich features** (rolling statistics, cross-tag ratios, lagged values from related sensors).
+- You care more about **predictive accuracy** than interpretability.
+
+**The critical baseline discipline:** Never deploy an ML model without comparing it to a simple classical baseline. If your LSTM doesn't beat a Holt-Winters model on your specific problem, the LSTM is adding complexity without value. In process industries, this happens more often than ML practitioners expect — many process signals are well-described by low-order linear models.
+
+**Industrial example:** Predicting the next 15 minutes of a reactor temperature given only its own history → ARIMA will likely suffice. Predicting the remaining useful life of a catalyst given 50 correlated sensor tags over 6 months → gradient boosting or a multivariate model is justified.
+
+---
+
+*End of Phase 2. Key takeaway: Classical methods are your baselines and your interpretability tools. Exponential smoothing for tracking and smoothing, ARIMA for modeling autocorrelation structure, Kalman filter for state estimation and innovation-based detection. Always fit one of these before reaching for more complex models. The residuals from these models are your first anomaly detection signal.*
+
+# Phase 3: Anomaly Detection Foundations
+
+## 3.1 Taxonomy of Anomalies
+
+Not all anomalies are the same. The type of anomaly determines which detection method works.
+
+**Point anomaly:** A single observation that is abnormal regardless of context. A reactor temperature of \(900\,^{\circ}\mathrm{C}\) when the normal range is \(350\)–\(420\,^{\circ}\mathrm{C}\). These are easy — a simple threshold catches them.
+
+**Contextual anomaly:** An observation that is only abnormal given its context. A cooling water outlet temperature of \(40\,^{\circ}\mathrm{C}\) is normal on a July afternoon; it's anomalous on a January night. The *value* is ordinary; the *context* (time, season, operating mode, ambient conditions) makes it anomalous.
+
+**Collective anomaly:** A sequence of observations that is anomalous as a group, even though each individual observation may look normal. A compressor vibration signal that slowly increases by \(0.1\,\mathrm{mm}/\mathrm{s}\) per day for 30 days — no single reading is flagged, but the upward trend is the anomaly. This is the hardest type to detect and the most industrially important.
+
+![Diagram: Three types of anomalies](images/phase3-anomaly-types.svg)
+*Diagram should show: A single time-series plot (e.g., reactor temperature over time). Mark three regions: (1) a point anomaly — a single sharp spike well outside the normal range, (2) a contextual anomaly — a value that's normal magnitude but occurs during a period (e.g., nighttime, marked by a shaded background) when it shouldn't, (3) a collective anomaly — a subtle upward drift over many points, none individually extreme, with a bracket indicating "anomalous as a pattern, not as individual points." Use distinct colors/annotations for each type.*
+
+**Why this matters for method selection:**
+- Point anomalies → statistical thresholds, z-scores, isolation forest work fine.
+- Contextual anomalies → you need a model of "expected given context" (regression, conditional distribution). The anomaly is in the *residual*, not the raw value.
+- Collective anomalies → you need methods that look at sequences: change-point detection, matrix profiles, sliding-window features.
+
+**Industrial implication:** Most real-world process anomalies that matter are contextual or collective. Point anomalies (sensor spikes, range violations) are usually caught by existing DCS alarm systems. The value a data scientist adds is detecting the subtle contextual and collective anomalies that operators can't see by watching individual trend screens.
+
+---
+
+## 3.2 Supervised vs. Semi-Supervised vs. Unsupervised Anomaly Detection
+
+**The label reality in industrial settings:**
+
+In process plants, you almost never have clean anomaly labels. What you *do* have:
+
+| What Exists | Quality as Labels |
+|-------------|-------------------|
+| Maintenance work orders | Partial: tell you what was fixed, not when the problem started |
+| DCS alarm logs | Noisy: thousands of alarms, most are nuisance |
+| Operator logbooks | Inconsistent: different operators record different things |
+| Shutdown records | Good for macro events, no help for early detection |
+| Root cause analysis reports | High quality but extremely rare (major incidents only) |
+| Lab results flagged as off-spec | Useful for quality anomalies, delayed by hours/days |
+
+**This means your realistic options are:**
+
+**Unsupervised (most common starting point):** Learn "normal" from unlabeled data, flag deviations. Assumes the training data is mostly normal — which is true for most plant operations (anomalies are rare). Methods: isolation forest, autoencoders, PCA-based monitoring, LOF.
+
+**Semi-supervised:** Train exclusively on known-good data (e.g., a stable operating period vetted by engineers), then flag anything that deviates from this baseline. This is the dominant paradigm in industrial anomaly detection. It's "one-class classification" — you model the normal class and call everything else anomalous.
+
+**Supervised (rare luxury):** If you have enough labeled anomalies (typically from historical incident databases), you can train a classifier. In practice, this works for well-characterized failure modes (e.g., "compressor surge" has a known signature that's been observed 50+ times across a fleet of identical machines). It does not work for novel failure modes.
+
+**Practical recommendation:** Start semi-supervised. Select a "golden period" of stable, normal operation (vetted by process engineers). Train your model on this period. Everything it doesn't recognize is an anomaly candidate. As you deploy and operators provide feedback (true positive / false positive labels on alerts), you gradually move toward supervised for known failure modes while maintaining unsupervised coverage for novel events.
+
+---
+
+## 3.3 Distance-Based Methods
+
+**\(k\)-NN distance:** An observation is anomalous if its \(k\)-th nearest neighbor (in feature space) is far away. Normal points cluster together; anomalies are isolated.
+
+**LOF (Local Outlier Factor):** Refines \(k\)-NN distance by comparing each point's local density to the density of its neighbors. A point in a sparse region surrounded by dense regions is anomalous. This handles datasets with clusters at different densities — a point that's normal in a dense cluster would be anomalous in a sparse one.
+
+**Analogy:** Think of LOF like a local normalization. In computer vision, an object at one scale might be normal in one image region but anomalous in another with different context. LOF does this in feature space — it asks "is this point unusual *relative to its neighborhood*?" not just "is this point far from the global mean?"
+
+**Assumptions and limitations:**
+- Requires a meaningful distance metric. For high-dimensional sensor data, Euclidean distance becomes unreliable (the "curse of dimensionality" — all points become roughly equidistant). You'll need dimensionality reduction (PCA, autoencoders) or careful feature selection.
+- Computationally expensive for large datasets: \(k\)-NN search is \(O(n^2)\) naively, \(O(n \log n)\) with tree structures.
+- These are static methods — they don't account for temporal ordering. Point \(A\) followed by point \(B\) might be normal, while \(B\) followed by \(A\) is anomalous. \(k\)-NN/LOF can't see this.
+
+**Industrial example:** Represent each 15-minute window of a compressor's operation as a vector of [suction pressure, discharge pressure, suction temperature, discharge temperature, power, vibration]. LOF on these vectors can identify windows where the operating point is unusual relative to similar conditions — e.g., abnormally high power consumption for a given pressure ratio, suggesting reduced efficiency.
+
+---
+
+## 3.4 Statistical Methods
+
+**Z-score:** For residual or value \(y_t\) with mean \(\mu\) and standard deviation \(\sigma\),
+
+$$z_t = \frac{y_t - \mu}{\sigma}.$$
+
+Flags points more than \(k\) standard deviations from the mean (threshold on \(|z_t|\)).
+
+**Grubbs' test:** Tests whether the most extreme value in a sample is an outlier, assuming the data is normally distributed.
+
+**ESD (Extreme Studentized Deviate):** Generalization of Grubbs' for detecting multiple outliers.
+
+**The critical assumption:** All of these assume the data is **stationary** (or at least that mean and variance are constant over the window you're computing them on). Applying a z-score to a trending signal will flag the early or late values as anomalous simply because they're far from the overall mean — they're not anomalies, they're trends.
+
+**How to use them correctly on process data:**
+1. Remove trend and seasonality first (Phase 1.4).
+2. Apply statistical tests to the **residuals**, not the raw signal.
+3. Use a **rolling window** z-score if the residual distribution changes slowly over time:
+
+$$z_t = \frac{r_t - \mu_{[t-w,\,t-1]}}{\sigma_{[t-w,\,t-1]}}.$$
+
+**Window size tradeoff:** Too small → noisy estimates of $\mu$ and $\sigma$, high false positive rate. Too large → slow to adapt, may include data from different operating regimes. Typical starting points for 1-minute process data: 1–4 hours for fast process dynamics, 1–7 days for slow degradation.
+
+**Industrial example:** A rolling z-score on the residuals of a reactor temperature model (after removing the trend from catalyst aging and the daily ambient cycle). A z-score exceeding 3 suggests a process disturbance not explained by the model — a feed composition upset, a cooling water anomaly, or an instrument fault.
+
+**Common failure modes:**
+- Applying z-scores to raw (non-detrended) data.
+- Using a global mean/std from training data without checking if the distribution has shifted.
+- Assuming normality when the data is skewed (e.g., concentration measurements near zero). Use robust alternatives: median absolute deviation (MAD) instead of standard deviation.
+
+---
+
+## 3.5 Density-Based and Ensemble Methods
+
+**Isolation Forest:** The key insight is that anomalies are easier to isolate than normal points. The algorithm builds random trees by randomly selecting a feature and a random split point. Anomalous points (being few and different) get isolated in fewer splits — they have shorter average path lengths in the trees.
+
+**Analogy from gradient boosting:** You understand random forests — isolation forest uses the same tree structure but inverts the objective. Instead of predicting a target, it measures how quickly each point gets isolated. It's an ensemble of random trees where short path length = anomalous.
+
+**Strengths:** Scales linearly with data size (\(O(n \log n)\)), handles high-dimensional data well, no distance metric needed, no distribution assumptions. One of the best general-purpose anomaly detectors.
+
+**One-Class SVM:** Learns a boundary around the normal data in kernel space. Everything outside the boundary is anomalous. Works well with RBF kernels when the normal data occupies a compact region. Less scalable than isolation forest for large industrial datasets.
+
+**Autoencoders for anomaly detection:** Train an autoencoder to reconstruct normal data. Anomalies produce high reconstruction error because the autoencoder has never learned to reconstruct abnormal patterns.
+
+**Analogy you know well:** You've used autoencoders in deep learning. The anomaly detection version is identical in architecture — the insight is that reconstruction error *is* the anomaly score. A denoising autoencoder trained on normal compressor data will faithfully reconstruct normal vibration patterns but produce high error on patterns associated with bearing degradation, because those patterns weren't in the training data.
+
+![Diagram: Autoencoder anomaly detection](images/phase3-autoencoder-anomaly.svg)
+*Diagram should show: Left — input time window of sensor data flowing into an encoder (compression bottleneck) and decoder producing a reconstruction. Middle — for normal data, input and reconstruction are similar (low error). Right — for anomalous data, reconstruction fails to capture the abnormal pattern (high error). Below — a time series of reconstruction error with a threshold line, with anomalous periods highlighted where error exceeds the threshold.*
+
+**Choosing the bottleneck dimension:** Too large → the autoencoder memorizes and reconstructs everything, including anomalies (no detection power). Too small → it can't even reconstruct normal data, generating false alarms everywhere. Tune on a validation set of known-normal data — the bottleneck should be large enough that normal reconstruction error is low but small enough that it can't represent rare anomalous patterns.
+
+**Common failure modes:**
+- Training the autoencoder on data that includes anomalies. Since anomalies are rare, the autoencoder won't focus on them, but if a particular failure mode recurs frequently (e.g., monthly compressor surge events), it might learn to reconstruct it, defeating detection.
+- Using reconstruction error alone without considering the *pattern* of error. Two points with the same total reconstruction error might have very different error distributions across sensors — one might be sensor noise (uniform small errors) and the other a real process event (large error concentrated on a few related sensors).
+- Overfit autoencoder on normal data: reconstructs normal data perfectly but also anomalous data if the anomaly is a mild variation of normal patterns.
+
+---
+
+## 3.6 Evaluation When Labels Are Scarce
+
+**Why accuracy is meaningless:** If anomalies are \(0.1\%\) of your data (typical in stable plant operations), a model that predicts “normal” for everything achieves \(99.9\%\) accuracy. Useless.
+
+**Why F1 can mislead:** \(F_1\) is the harmonic mean of precision and recall. With extreme class imbalance, a model with \(50\%\) precision and \(50\%\) recall gets \(F_1 = 0.50\) — which sounds decent. But in production, \(50\%\) precision means half your alerts are false alarms. Operators will ignore the system within a week.
+
+**The metrics that matter in industrial anomaly detection:**
+
+**Precision (at the alert level):** Of the alerts generated, what fraction pointed to real problems? This directly maps to operator trust. Target: \(> 80\%\) in production.
+
+**Recall (at the event level):** Of the real events that occurred, what fraction did the system catch? Note the critical distinction: compute recall per *event* (did we detect the problem at all, even if we missed some individual anomalous points?), not per *point*.
+
+**Time-to-detection:** How early before the event became obvious did the system alert? This is the real value proposition — catching problems hours or days before they'd be noticed otherwise.
+
+**False alarm rate:** Alerts per unit time during known-normal operation. This is what determines whether operators trust or ignore the system.
+
+**The precision-recall tradeoff in practice:**
+
+$$\text{More sensitive threshold} \implies \text{Higher recall, lower precision, more false alarms}$$
+$$\text{Less sensitive threshold} \implies \text{Lower recall, higher precision, fewer false alarms}$$
+
+For most industrial applications, err toward precision. Missing a few events is tolerable if operators trust the system. A system that cries wolf loses all value regardless of its recall.
+
+**Evaluation strategies without labels:**
+- **Expert review:** Show ranked anomaly scores to process engineers. They can often quickly confirm or reject the top anomalies. This gives you a partial labeled set.
+- **Known event alignment:** Align detected anomalies with known events (shutdowns, maintenance, incidents). If your anomalies cluster before known problems, the system is working.
+- **Stability analysis:** Run the model on known-stable periods. Any alerts during these periods are definitionally false positives.
+
+**Common failure modes:**
+- Reporting area under ROC curve (AUC-ROC). With extreme imbalance, AUC-ROC is misleadingly optimistic — use AUC-PR (precision-recall) instead.
+- Computing point-level \(F_1\) on anomaly segments. If the system detects a 4-hour event but the labeled event is 5 hours, naive point-level evaluation penalizes the 1-hour mismatch heavily. Use event-level evaluation or a tolerance window.
+- Optimizing threshold on test data. Set thresholds on a validation set (known-normal period + a few known events), then evaluate on a held-out period.
+
+---
+
+*End of Phase 3. Key takeaway: Most industrial anomalies are contextual or collective, not point anomalies. You'll likely work in a semi-supervised setting (model normal, flag deviations). Autoencoder reconstruction error and isolation forest are strong general-purpose methods. Evaluate on precision at the alert level and recall at the event level, not accuracy or \(F_1\). Operator trust is your ultimate metric.*
+
+# Phase 4: Time-Series Anomaly Detection
+
+## 4.1 Residual-Based Detection
+
+This is the bridge between Phase 2 and Phase 3. The idea is simple and powerful:
+
+1. **Fit a time-series model** to the signal (ARIMA, exponential smoothing, Kalman filter, or even a regression against known inputs like ambient temperature or feed rate).
+2. **Compute residuals:** $r_t = y_t - \hat{y}_t$
+3. **Apply anomaly detection to the residuals** (z-score, rolling threshold, isolation forest — any method from Phase 3).
+
+**Why this works:** The model captures the *expected* behavior — the trend, seasonality, autocorrelation, and response to known inputs. The residual is what's *unexplained*. Anomalies live in the unexplained.
+
+**Analogy:** This is exactly like the "reconstruction error" approach for autoencoders, but using interpretable statistical models instead of neural networks. The model "reconstructs" the expected value; the residual is the reconstruction error.
+
+**The quality of your anomaly detection is capped by the quality of your model.** A poor model produces large residuals during normal operation (high noise floor), drowning out real anomalies. A good model produces small, white-noise residuals during normal operation, so even a slight process disturbance stands out.
+
+**Residual diagnostics checklist:**
+- Are residuals approximately zero-mean? (If not, the model has a bias.)
+- Are residuals constant-variance? (If variance changes, use a rolling threshold, not a global one.)
+- Are residuals uncorrelated? (Check ACF. If there's remaining autocorrelation, the model is missing structure — go back and improve it.)
+- Are residuals approximately normal? (Affects threshold calibration. Use MAD for robust thresholds if non-normal.)
+
+**Industrial example:** Model a heat exchanger outlet temperature as a function of inlet temperature, flow rate, and ambient temperature (regression). The residuals represent deviations not explained by these inputs. A gradual upward drift in residuals → fouling (the exchanger is less efficient than the model expects). A sudden spike → process upset or sensor fault.
+
+**Common failure modes:**
+- Using a model that's too flexible (high-order ARIMA, overfit neural network) — it absorbs the anomalies into its predictions, producing small residuals even during anomalous periods. The model "explains away" the anomaly.
+- Not retraining the model as the process drifts. A model trained on data from a fresh catalyst will produce false alarms as the catalyst ages, because the aging is normal but wasn't in the training data.
+- Ignoring the model's prediction uncertainty. A residual of \(5\,^{\circ}\mathrm{C}\) means different things at a point where the model's \(95\%\) prediction interval is \(\pm 2\,^{\circ}\mathrm{C}\) vs.\ \(\pm 10\,^{\circ}\mathrm{C}\). Use *standardized* residuals: \(r_t / \hat{\sigma}_t\).
+
+---
+
+## 4.2 Change-Point Detection
+
+Change-point detection identifies moments when the statistical properties of a time series abruptly shift. This is distinct from anomaly detection: an anomaly is a *deviant observation*, while a change-point marks a *regime transition*.
+
+**Why this matters industrially:** Many real-world "anomalies" are actually regime changes — a catalyst suddenly loses activity, a heat exchanger transitions from clean to fouled, a compressor enters surge. The values after the change may each look individually normal (the system found a new steady state), but the *fact that a shift occurred* is the signal.
+
+**Three key methods:**
+
+**CUSUM (Cumulative Sum):**
+Track the cumulative sum of deviations from a target mean. When the process is on target, the cumulative sum random-walks around zero. When the mean shifts, the cumulative sum develops a persistent trend.
+
+$$S_t = \max\left\{0,\, S_{t-1} + (y_t - \mu_0 - k)\right\}$$
+
+where $\mu_0$ is the target mean and $k$ is a slack parameter (minimum shift size you want to detect). An alarm triggers when $S_t$ exceeds threshold $h$.
+
+**Intuition:** CUSUM integrates small, consistent deviations. A single outlier bumps $S_t$ up but it decays back. A sustained shift causes $S_t$ to grow steadily. It's a detector for collective anomalies — persistent shifts too small for any single point to trigger a threshold.
+
+**PELT (Pruned Exact Linear Time):**
+An offline algorithm that finds the optimal set of change-points that minimizes a penalized cost function. "Offline" means it processes the entire series at once — use it for historical analysis, not real-time detection.
+
+**Bayesian Online Change-Point Detection (BOCPD):**
+Maintains a probability distribution over "how long since the last change-point" (the run length). At each time step, it updates this distribution. When the probability of run length = 0 spikes, a change-point is likely.
+
+**Analogy:** BOCPD is like a Bayesian version of attention in transformers. It dynamically decides how far back in time to look — when a change-point occurs, it "resets" and starts building a new context window.
+
+![Diagram: Change-point detection methods comparison](images/phase4-changepoint-methods.svg)
+*Diagram should show: A single time series with two true change-points (mean shifts at t=200 and t=500). Below it, three panels: (1) CUSUM statistic rising and triggering at each change-point, (2) PELT output showing detected segments as colored blocks, (3) BOCPD run-length posterior as a heatmap (time on x-axis, run length on y-axis, probability as color intensity) showing the run length resetting to zero at change-points.*
+
+**Choosing a method:**
+- **CUSUM:** Real-time, simple, well-understood. Good for monitoring a specific parameter against a target. Standard in statistical process control (SPC).
+- **PELT:** Offline historical analysis. "Where did things change in this 2-year dataset?" Fast and exact.
+- **BOCPD:** Online with principled uncertainty. Best for situations where you need to adapt to change-points in real time and want a probability of change rather than a binary alarm.
+
+**Industrial example:** Monitoring catalyst activity (measured as conversion rate normalized for operating conditions). CUSUM on the conversion residuals detects the point where deactivation rate accelerated — this might be weeks before the product quality drops below spec, giving operations time to plan a catalyst change.
+
+**Common failure modes:**
+- CUSUM slack parameter $k$ too large → misses small shifts. Too small → triggers on noise.
+- PELT penalty too low → over-segments (finds change-points in noise). Too high → misses real changes. Use information criteria (BIC-based penalty) as a starting point.
+- Not distinguishing level shifts from trend changes. A step change in mean and a gradual ramp-up look different but both trigger change-point detectors. Check the change type post-detection.
+
+---
+
+## 4.3 Matrix Profiles
+
+The matrix profile is a data structure that, for every subsequence of length $m$ in a time series, stores the **distance to its nearest neighbor** (the most similar subsequence elsewhere in the series).
+
+**The "Shazam for time-series" intuition:** Shazam works by finding the closest match in a database of known fingerprints. The matrix profile does the same — for every window, it finds the best match. Subsequences with *no* good match (high matrix profile value) are **discords** — they're unique, never-before-seen patterns. These are your anomalies.
+
+Conversely, subsequences with very good matches (low matrix profile value) that recur throughout the data are **motifs** — repeated patterns. In a plant, motifs might be normal startup sequences, batch cycle phases, or daily operational patterns.
+
+**How it works (high level):**
+1. Slide a window of length $m$ across the time series.
+2. For each window position $i$, compute the z-normalized Euclidean distance to every other window position $j$.
+3. Store the minimum distance (nearest neighbor distance) as \(\mathrm{MP}[i]\).
+4. The index of the nearest neighbor is stored in the **matrix profile index**.
+
+**Efficiency:** The naive approach is \(O(n^2 m)\), but the STOMP/STUMPY algorithms compute it in \(O(n^2)\) by exploiting the structure of sliding-window distance computations. The `stumpy` library implements this efficiently and can handle millions of data points.
+
+**Why this is powerful for industrial data:**
+- **Assumption-free:** No model to fit, no distribution to assume. Just pattern matching.
+- **Discovers unknown anomalies:** You don't need to specify what you're looking for. The highest matrix profile values are the most unusual patterns in the data.
+- **Motif discovery is equally valuable:** Finding repeated patterns (motifs) helps you understand normal behavior, identify operational modes, and detect when a "normal" pattern stops appearing.
+
+**Industrial example:** Compute the matrix profile of a compressor's vibration signal (or a derived feature like vibration RMS in 1-minute windows) with $m = 60$ (1-hour subsequences). Discords — 1-hour windows that don't match anything else in the history — might correspond to: early bearing degradation, unusual surge events, or operating conditions the compressor has never experienced.
+
+**The window size $m$ tradeoff:**
+- Too small → catches only local spikes (like point anomaly detection; you don't need a matrix profile for this).
+- Too large → averages out short anomalies; also computationally more expensive and requires anomalous patterns to be sustained.
+- Start with \(m\) corresponding to \(1\)–\(4\) times the characteristic process time scale (e.g., if a reactor takes 30 minutes to respond to a disturbance, try \(m\) = 30–120 minutes of data).
+
+**Common failure modes:**
+- Not z-normalizing subsequences. Without normalization, distance is dominated by level differences, not shape differences. A normal pattern at a different operating level looks like a discord.
+- Interpreting matrix profile values without context. A high value might be a true anomaly or might just be a rare-but-normal operating condition (e.g., a planned rate change that only happens twice a year). Combine with domain knowledge.
+- Using matrix profiles on multivariate data naively. The standard matrix profile is univariate. For multivariate data, compute profiles per tag and combine, or use the multidimensional matrix profile (mSTAMP in `stumpy`).
+
+---
+
+## 4.4 Multivariate Anomaly Detection: PCA-Based Monitoring
+
+In a real plant, no sensor operates in isolation. A reactor temperature, coolant flow, catalyst bed pressure drop, and product composition are all coupled by thermodynamics and fluid mechanics. Anomaly detection must consider tags *together*.
+
+**PCA (Principal Component Analysis) for process monitoring** — the industrial standard, often called **MSPC (Multivariate Statistical Process Control)**:
+
+1. Collect a matrix of \(n\) time points \(\times\) \(p\) sensor tags during normal operation.
+2. Standardize each tag (zero mean, unit variance).
+3. Compute PCA. The first $k$ principal components capture the correlated "normal" behavior — the process sitting within its normal operating envelope.
+4. Monitor two statistics:
+   - **Hotelling's $T^2$:** Measures distance from the mean *within* the PCA model space (the first $k$ components). High $T^2$ = the process is at an unusual but still "explainable" operating point. Think of it as an unusual combination of the main process modes.
+   - **$Q$ statistic (SPE — Squared Prediction Error):** Measures distance *outside* the PCA model space (the residual from the discarded components). High $Q$ = the correlation structure between tags has broken down. Something is happening that the normal model can't represent.
+
+![Diagram: PCA-based T² and Q monitoring](images/phase4-pca-monitoring.svg)
+*Diagram should show: Left — a 3D scatter plot of normal operating data (a cloud/ellipsoid) with PC1 and PC2 defining the model plane and the third direction being the residual space. Show a normal point projected onto the plane (its T² is the distance from center within the plane, its Q is the distance from the plane). Show an anomalous point with high Q (far from the plane). Right — time series of T² and Q statistics with control limits (dashed lines), showing an anomalous event where Q spikes above its limit while T² may or may not spike.*
+
+**Analogy:** PCA-based monitoring is dimensional reduction for anomaly detection. You've used PCA or autoencoders to reduce dimensions. Here, the reconstruction error *is* the $Q$ statistic, and the distance in latent space *is* $T^2$. If you replace PCA with an autoencoder, you get a nonlinear version of the same framework.
+
+**$T^2$ vs. $Q$ — what they tell you:**
+
+| | $T^2$ high, $Q$ normal | $T^2$ normal, $Q$ high | Both high |
+|-|------------------------|------------------------|-----------|
+| Meaning | Unusual operating point but correlations intact | Operating point is normal but correlations broke | Both — unusual point with broken correlations |
+| Example | Running at much higher throughput than usual (everything scaled proportionally) | Heat exchanger fouled — temperature is high relative to flow and cooling, breaking the normal T-F correlation | Compressor surge — everything is off simultaneously |
+
+**Why this is the industrial standard:** Chemical engineers have used $T^2$ and $Q$ charts since the 1990s. They're interpretable (contribution plots show *which* sensors drive the anomaly score), statistically grounded, fast to compute, and work well with the hundreds of correlated tags found in a typical process unit.
+
+**Contribution plots:** When $T^2$ or $Q$ exceeds its limit, compute each variable's contribution to the statistic. This tells operators *which* sensors are behaving abnormally — essential for diagnosis. Without contribution plots, the operator gets "something is wrong" but not "what's wrong."
+
+**Multivariate autoencoders** extend this to nonlinear relationships. Train an autoencoder on the \(n \times p\) matrix of normal operating data. The reconstruction error per tag plays the same role as PCA contributions. The total reconstruction error is the analog of $Q$.
+
+**Common failure modes:**
+- Choosing $k$ (number of retained PCs) poorly. Too few → high noise in $T^2$, real process variation thrown into $Q$. Too many → anomalies absorbed into the model. Use scree plot + process knowledge.
+- Training on data that includes multiple operating regimes (startup, shutdown, different product grades). PCA blurs them together, and the "normal" envelope becomes so wide it catches nothing. Segment by regime first.
+- Computing PCA on raw (non-standardized) data. The tag with the largest variance (often flow rates, which might be 0–1000, vs. temperatures at 300–350) dominates all components.
+- Ignoring temporal dynamics. Standard PCA treats each time point independently. If you need to capture dynamic behavior (the relationship between tag A now and tag B 5 minutes ago), use Dynamic PCA (include time-lagged columns) or dynamic latent variable models.
+
+---
+
+## 4.5 Sliding-Window Feature Extraction
+
+Many anomaly detection methods work on feature vectors, not raw time points. The bridge from raw time-series to feature vectors is the **sliding window**.
+
+**The approach:**
+1. Define a window of length $w$.
+2. Slide it across the time series (or multivariate time series) at some step size $s$.
+3. For each window, compute summary features.
+4. Apply any anomaly detection method from Phase 3 to the resulting feature matrix.
+
+**Common features per window:**
+
+| Feature | What It Captures |
+|---------|-----------------|
+| Mean, median | Level |
+| Standard deviation, IQR | Variability / noise level |
+| Skewness, kurtosis | Distribution shape changes |
+| Min, max, range | Extremes |
+| Number of zero-crossings (of detrended signal) | Oscillation frequency |
+| Slope (linear fit) | Local trend |
+| Autocorrelation at lag 1 | Smoothness / persistence |
+| Spectral entropy | Complexity of frequency content |
+| RMS (root mean square) | Energy |
+
+**The window-size tradeoff (again):**
+- Smaller windows → higher temporal resolution, but noisier features, more sensitive to point anomalies.
+- Larger windows → smoother features, captures collective anomalies, but lower temporal resolution, may smear boundaries of anomalous periods.
+
+**Rule of thumb:** The window should be at least \(2\)–\(3\) times the characteristic time scale of the anomaly you want to detect. For a heat exchanger that takes 30 minutes to noticeably foul, a 1-hour window captures the trend. For a compressor surge event lasting 10 seconds, you need sub-minute windows (which may require higher-resolution data than your historian provides).
+
+**Step size \(s\):** Using \(s = w\) (non-overlapping windows) is faster but can split an anomaly across window boundaries. Using \(s = 1\) (maximally overlapping) gives the best resolution but is roughly \(w\) times as expensive. A common compromise is \(s = w/4\) (\(75\%\) overlap).
+
+**Industrial example:** For a multivariate compressor health monitor with 8 sensor tags, use $w$ = 60 minutes, $s$ = 15 minutes. For each window, compute [mean, std, slope, autocorrelation_lag1] for each tag → 32 features. Feed into an isolation forest. Windows with high anomaly scores flag periods of unusual compressor behavior.
+
+---
+
+## 4.6 "Something Unusual" vs. "Something Bad"
+
+This is the most important conceptual distinction in applied anomaly detection.
+
+**Anomaly detection finds statistical deviations from normal.** It does not distinguish between:
+- A process upset that will cause equipment damage (bad)
+- A planned rate change by the operator (unusual but fine)
+- A sensor recalibration (the sensor changed, not the process)
+- A rare but normal operating condition (e.g., processing a different feedstock once a quarter)
+
+**The gap between "unusual" and "bad" can only be closed with domain knowledge.** Statistical methods will always flag rate changes, feed switches, and calibration events as anomalies — because they *are* statistically unusual. The question is whether they're *operationally concerning*.
+
+**Strategies for closing the gap:**
+1. **Context enrichment:** Annotate anomalies with operating mode, recent setpoint changes, maintenance activity, and lab results. An anomaly during a planned rate change is explained; the same anomaly during steady-state operation is concerning.
+2. **Physical plausibility checks:** A temperature anomaly that correlates with flow and pressure changes (consistent with thermodynamics) suggests a real process shift. A temperature anomaly with no correlated changes elsewhere suggests a sensor fault.
+3. **Root cause contribution:** Use contribution plots (PCA) or SHAP values (ML models) to identify *which* variables drive the anomaly score. Operators can quickly assess whether the combination makes physical sense.
+4. **Operator feedback loop:** Present anomalies to operators, collect labels (real / false alarm / explained), use these labels to refine the model and suppress known benign patterns.
+
+---
+
+## 4.7 Handling Regime Changes
+
+A process plant does not operate in a single steady state. It cycles through:
+- **Startup / shutdown** (wildly non-stationary, every tag changing rapidly)
+- **Grade changes / product transitions** (setpoints changing, process seeking new steady state)
+- **Steady-state at different rates** (\(70\%\) vs.\ \(100\%\) capacity — different baselines)
+- **Degraded operation** (running with a fouled exchanger, bypassed equipment, or derated compressor)
+
+**Anomaly detection must be regime-aware.** A temperature of \(350\,^{\circ}\mathrm{C}\) is normal at \(100\%\) rate and anomalous at \(70\%\) rate. A pressure fluctuation of \(\pm 5\,\mathrm{psi}\) is normal during startup and anomalous during steady state.
+
+**Two approaches:**
+
+**1. Explicit regime segmentation (preferred):**
+- Define operating regimes using process knowledge: production rate thresholds, unit status flags, time-based rules for startup/shutdown.
+- Train separate anomaly detection models per regime, or exclude non-steady-state data from training and only monitor during steady state.
+- Gate your alerts: suppress anomaly alerts during known transient periods.
+
+**2. Regime as a feature:**
+- Include operating mode indicators (production rate, active/inactive flags, time-since-startup) as features in your model. The model learns that certain patterns are normal given the regime context.
+- This works if you have enough data from each regime. Rare regimes (annual turnaround startup) may not have enough data for the model to learn.
+
+**The practical default:** Start with explicit segmentation. Label each time period as "steady state at rate X," "startup," "shutdown," "transition," or "abnormal." Only run anomaly detection during steady-state periods. This eliminates the largest source of false positives in industrial anomaly detection. Expand to transient monitoring later once the steady-state system is proven.
+
+**Common failure modes:**
+- Not segmenting at all. This is the #1 source of false alarms in industrial anomaly detection. Every startup triggers hundreds of alerts.
+- Using a single "normal" model that was trained on mixed-regime data. The model learns a wide "normal" envelope that includes startup transients, so it fails to flag anomalies during steady state.
+- Hardcoding regime boundaries. Startups don't always follow the same timeline. Use process-based criteria (e.g., “steady state = production rate within \(\pm 5\%\) of target for \(> 30\) minutes and all critical temperatures within \(\pm 10\,^{\circ}\mathrm{C}\) of setpoint”) rather than “\(t = \text{startup\_time} + 4\,\mathrm{h}\)”.
+
+---
+
+*End of Phase 4. Key takeaway: Time-series anomaly detection is about fitting a model of "expected" behavior and flagging what's left. Residual-based methods connect your time-series models to anomaly scores. Change-point detection catches regime shifts. Matrix profiles find unusual patterns without any model at all. PCA-based monitoring is the industrial standard for multivariate systems. But none of these methods know "unusual" from "bad" — that requires domain knowledge, context, and operator feedback.*
+
+# Phase 5: Industrial Application and Deployment
+
+## 5.1 Historian Data Quality
+
+Before any analysis, you must understand how bad your data can be. Historian systems are recording infrastructure, not analytical infrastructure, and they introduce systematic artifacts.
+
+**Sensor freezes:** A sensor value that stops updating but the historian continues reporting the last known value. On a trend screen, this looks like a perfectly flat line. In your data, it looks like repeated identical values — which is physically implausible for an analog measurement (even a stable temperature fluctuates by the sensor's noise floor). **Detection:** flag runs of identical values longer than $n$ samples (where $n$ depends on the sensor type and compression settings).
+
+**Range clamps:** Sensors have configured ranges (e.g., \(0\)–\(500\,^{\circ}\mathrm{C}\) for a thermocouple transmitter). When the true value exceeds the range, the historian records the min or max. This creates flat lines at exactly the configured limits. **Detection:** flag values exactly at known transmitter limits.
+
+**Bad-quality flags:** Most historians store a quality code alongside each value. Values with bad quality (sensor fault, communication error, manual override) should be masked before analysis. **Critical:** these flags are often stored but not exported by default. Ensure your data extraction includes quality codes.
+
+**Communication dropouts:** Entire groups of tags go missing simultaneously when a controller or network link fails. This creates coordinated gaps across many tags — which can look like a collective anomaly to a multivariate model. **Detection:** if many tags go missing at the same time, it's infrastructure, not process.
+
+**Compression artifacts:** Swinging-door compression (Phase 1.7) distorts the data. Fast transients are under-sampled, and the reconstructed signal has a characteristic "sawtooth" shape between recorded points. For high-frequency analysis, you may need to request uncompressed data from the historian (if available) or use higher-resolution DCS data.
+
+**Practical checklist before any modeling:**
+1. Check for frozen sensors (runs of identical values).
+2. Check for range-clamped values (at known transmitter limits).
+3. Filter on quality flags.
+4. Identify and mask communication dropouts (many tags missing simultaneously).
+5. Understand each tag's compression settings (deadband, deviation).
+6. Verify physical units (historian tag configurations can be wrong).
+
+---
+
+## 5.2 Shutdown/Startup Masking and Regime Segmentation
+
+This is a prerequisite, not an afterthought. If you skip this step, your anomaly detection system will be dominated by startup/shutdown false alarms and will be abandoned by operators within the first week.
+
+**Implementing regime segmentation:**
+
+**Step 1: Define regimes using process knowledge.** Work with operations engineers to identify:
+- Key indicators of operating state (production rate, main feed flow, compressor running/stopped, furnace firing rate).
+- Thresholds or rules that define each regime (e.g., "steady state = production rate > 80% of capacity and all major equipment running").
+- Known transition patterns (typical startup duration, rate change ramp rate).
+
+**Step 2: Build a regime labeling function.** This transforms your raw sensor data into a categorical regime label at each time step. Keep it deterministic and auditable — operators need to understand why a given period was classified as "startup" vs. "steady state."
+
+**Step 3: Apply regime-dependent processing:**
+- Train anomaly detection models only on steady-state data (or on each regime separately if you have enough data per regime).
+- Suppress alerts during startup, shutdown, and planned transitions.
+- Include transition periods in your masking — the period between "shutdown complete" and "steady state achieved" is a transition that follows different rules.
+
+**Step 4: Handle edge cases:**
+- **Unplanned shutdowns:** These *should* trigger alerts (they might be caused by the anomaly you're trying to detect). Mask only *planned* shutdowns.
+- **Partial shutdowns:** When one unit in a complex is down but others are running. The remaining units operate at different conditions, changing the normal baseline.
+- **Slow rate changes:** A gradual production ramp from 70% to 100% over 8 hours. Each rate has different normal values. Use rate-dependent models or segment into rate bands.
+
+---
+
+## 5.3 Alarm Rationalization
+
+**The problem:** A statistical anomaly detection system will generate statistical anomalies. Operators need actionable alerts — not "sensor 47 z-score is 3.2."
+
+**Mapping anomalies to actions:**
+
+| Anomaly Type | What It Tells the Operator | Actionable? |
+|-------------|---------------------------|-------------|
+| Single-tag threshold exceedance | "Temperature X is high" | Already in DCS alarms. You add no value. |
+| Model residual exceedance | "Temperature X is higher than expected given current conditions" | Yes — this is contextual detection the DCS can't do. |
+| Multivariate score ($T^2$ or $Q$) exceedance | "The relationship between tags has changed" | Actionable if paired with contribution plots showing *which* relationships changed. |
+| Change-point detected | "The process shifted at time T" | Actionable if paired with magnitude, affected tags, and temporal context. |
+| Gradual trend in anomaly score | "Something is slowly degrading" | Highly actionable — this is early warning of fouling, catalyst deactivation, etc. |
+
+**Alert design principles:**
+- **Severity levels:** Not all anomalies are equal. A z-score of 3.1 and 6.0 both exceed a threshold of 3.0, but they represent very different situations.
+- **Persistence filtering:** Require an anomaly to persist for $n$ consecutive time steps before alerting. This eliminates transient spikes from sensor noise or momentary process disturbances.
+- **Cooldown periods:** After an alert is generated, suppress repeat alerts for a configurable period. An operator doesn't need to be told about the same anomaly every minute for 4 hours.
+- **Grouping:** If 5 related tags all go anomalous simultaneously, generate one alert with all 5 tags, not 5 separate alerts. Use physical grouping (tags on the same equipment) or correlation (tags with correlated anomaly scores).
+- **Natural language summaries:** “Reactor R-101 outlet temperature is \(8\,^{\circ}\mathrm{C}\) above expected for current feed rate and catalyst age” is infinitely more useful than “Tag TI-4032 anomaly score \(= 0.87\)”.
+
+---
+
+## 5.4 Multivariate Process Monitoring: Health Scores
+
+A single anomaly score for an entire piece of equipment (or a process unit) is often more useful than individual tag scores. This is a **health score** or **health index**.
+
+**Construction approaches:**
+
+**1. PCA-based:** Use $T^2$ and $Q$ from a PCA model of all tags related to one piece of equipment. The combined statistic (or the max of the two, normalized) serves as the health score.
+
+**2. Autoencoder-based:** Total reconstruction error across all tags for a piece of equipment.
+
+**3. Weighted combination:** Assign weights to individual tag anomaly scores based on their criticality. A bearing temperature anomaly should contribute more to a compressor health score than an auxiliary oil filter differential pressure anomaly.
+
+**4. Physics-informed:** Derive health indicators from first-principles engineering relationships. For a heat exchanger, this might be the overall heat transfer coefficient $U$ (calculated from inlet/outlet temperatures and flow rates). Declining $U$ directly measures fouling — no anomaly detection model needed; the physics *is* the model.
+
+**The physics-informed approach is almost always preferred when available.** A declining $U$ value is interpretable, physically grounded, and directly actionable. A "PCA $Q$ statistic = 15.3" is not.
+
+**Industrial example (heat exchanger health):**
+$$U = \frac{Q_{\mathrm{duty}}}{A\,\Delta T_{\mathrm{lm}}}$$
+where \(Q_{\mathrm{duty}}\) is heat duty (from flow rates and temperature differences), \(A\) is the heat transfer area (known constant), and \(\Delta T_{\mathrm{lm}}\) is the log-mean temperature difference. Track $U$ over time. When it drops below a threshold, schedule cleaning.
+
+**Combining statistical and physics-based monitoring:** Use physics-based health indicators for well-understood degradation mechanisms (fouling, catalyst deactivation). Layer statistical anomaly detection on top to catch *unexpected* failure modes that the physics model doesn't cover.
+
+---
+
+## 5.5 Soft Sensor Drift vs. Process Drift vs. Instrument Drift
+
+When a model's predictions diverge from reality, the cause is one of three things, and your response is completely different for each:
+
+**Instrument drift:** A sensor is slowly going out of calibration. The process hasn't changed; the measurement has. **Diagnosis:** Compare against redundant sensors, lab measurements, or cross-check with heat/mass balances. **Response:** Recalibrate or replace the sensor. Don't retrain the model.
+
+**Process drift:** The actual process has changed — different feed composition, catalyst aging, fouling, ambient condition shift. **Diagnosis:** Multiple related sensors show consistent, physically plausible changes. Lab results confirm. **Response:** If the drift is understood (e.g., catalyst aging), incorporate it into the model (add catalyst age as a feature). If it's unexpected, investigate the root cause.
+
+**Model (soft sensor) drift:** The statistical relationships that the model learned have changed, but neither the instrument nor the process has changed in the way the model expects. This often happens when operating conditions move to a region the model was never trained on. **Diagnosis:** Process and instruments are verified as correct, but model residuals grow. **Response:** Retrain the model with data that covers the new operating region.
+
+**The diagnostic sequence:**
+1. **First, check instruments.** Compare the drifting sensor against independent measurements (lab data, redundant sensors, cross-calculations). If the instrument is drifting, stop here.
+2. **Then, check the process.** Are related tags moving consistently with what the physics would predict? If yes, the process is changing.
+3. **Finally, blame the model.** Only after ruling out instruments and process.
+
+**Common failure mode:** Retraining the model when the real problem is a drifting sensor. The retrained model learns to compensate for the sensor error, silently embedding a calibration offset. When the sensor is eventually recalibrated, the model is now wrong in the other direction.
+
+---
+
+## 5.6 False Positive Management
+
+**The fundamental law of industrial anomaly detection:** If operators don't trust the system, it has zero value regardless of its statistical performance.
+
+**Why false positives kill trust:**
+- An operator handles hundreds of DCS alarms per shift. Adding model-based alerts to this flood is counterproductive unless they have a high signal-to-noise ratio.
+- A single week of frequent false alarms can permanently destroy an operator's willingness to act on the system's alerts.
+- "The model that cries wolf" becomes an organizational meme that's nearly impossible to reverse.
+
+**Strategies to manage false positives:**
+
+**1. Start tight, loosen later.** Launch with conservative thresholds that produce few alerts (even if recall is poor). Demonstrate to operators that when the system alerts, it's worth investigating. Build trust, then gradually increase sensitivity.
+
+**2. Tiered alerts:** Level 1 = information only (logged, visible on a dashboard if someone looks). Level 2 = notification (pushed to the console, but not an alarm). Level 3 = alarm (requires operator acknowledgment). Start most model-based detections at Level 1. Promote to Level 2/3 only after validation.
+
+**3. Post-hoc filtering:** Before presenting an alert, apply a checklist:
+- Is the unit in steady state? (If no, suppress.)
+- Has there been a recent setpoint change? (If yes, explain by context.)
+- Are there data quality issues? (If yes, suppress and flag data quality.)
+- Has this exact alert pattern been seen before and deemed a false alarm? (If yes, suppress with annotation.)
+
+**4. Root cause explanation with every alert.** Even if the operator disagrees with the alert, they should be able to see *why* the model flagged it. Contribution plots, the specific tags driving the anomaly, and recent operating context should accompany every alert. An unexplained alert is always perceived as a false alarm.
+
+**5. Feedback mechanism:** Make it trivially easy for operators to label alerts as true positive, false positive, or acknowledged-but-not-actionable. Use this feedback for both immediate suppression and long-term model improvement.
+
+---
+
+## 5.7 Online vs. Batch Detection
+
+**Batch detection:** Process a chunk of historical data, find all anomalies, review offline. Used for: historical root cause analysis, model development, retrospective studies.
+
+**Online (streaming) detection:** Process each new data point (or short window) as it arrives, generate alerts in near-real-time. Used for: operational monitoring, early warning systems.
+
+**Key differences:**
+
+| Aspect | Batch | Online |
+|--------|-------|--------|
+| Data access | Full series, look forward and backward | Only past and present, no future |
+| Methods available | All (including PELT, bidirectional smoothers, STL) | Causal only (CUSUM, online BOCPD, recursive estimators) |
+| Latency requirement | None | Seconds to minutes |
+| Compute budget | Large (can run overnight) | Bounded per sample |
+| Threshold setting | Optimize on full dataset | Must be pre-set or adaptively estimated |
+
+**The practical deployment pattern:**
+1. **Develop models in batch mode** on historical data. Tune hyperparameters, validate against known events, optimize thresholds.
+2. **Deploy for online scoring** using only causal (past-looking) computations. Most models translate naturally: a trained PCA just projects new data; a trained autoencoder just reconstructs.
+3. **Run batch reanalysis periodically** (daily, weekly) to recalibrate thresholds, detect slow drifts, and catch collective anomalies that require longer windows than online detection provides.
+
+**Latency considerations for industrial processes:**
+- Most process anomalies evolve over minutes to hours. You don't need sub-second latency. A 1–5 minute scoring cycle is adequate for most applications.
+- Exception: safety-critical systems (compressor anti-surge, reactor runaway protection) require dedicated hardware-based systems with millisecond response. Model-based anomaly detection supplements these; it never replaces them.
+
+---
+
+## 5.8 Retraining Triggers and Concept Drift
+
+**Concept drift** in process data means the relationship between inputs and outputs has genuinely changed. This is not an anomaly — it's the new normal.
+
+**Common sources of concept drift:**
+- Catalyst replacement (new catalyst has different kinetics)
+- Equipment replacement or modification (new heat exchanger, re-tubed condenser)
+- Feed source change (different crude slate, different ammonia plant feedstock)
+- Seasonal changes (ambient temperature affecting cooling capacity)
+- Regulatory changes (new emissions limits changing operating targets)
+
+**When to retrain:**
+- After any major equipment change or turnaround.
+- When the rolling average of model residuals (on confirmed-normal data) shows a sustained bias.
+- When the false positive rate increases above the threshold operators will tolerate.
+- On a regular schedule (quarterly or semi-annually) as a maintenance baseline.
+
+**When NOT to retrain:**
+- During an active anomaly (you'd train the model to accept the anomalous behavior).
+- When the drift is caused by a sensor calibration issue (fix the sensor, don't mask it).
+- Without understanding *why* the model drifted (retraining without diagnosis hides problems).
+
+**Safe retraining protocol:**
+1. Identify a new "golden period" of normal operation under the new conditions (vetted by engineers).
+2. Retrain the model on this new data.
+3. Run the old and new models in parallel for a validation period.
+4. If the new model shows lower false positive rates and comparable detection on known events, switch.
+5. Archive the old model — you may need it if the process reverts (e.g., when the old feedstock returns).
+
+---
+
+## 5.9 From "Unusual" to "Needs Attention"
+
+This final section addresses the gap between statistical detection and operational action.
+
+**A statistical anomaly score is a starting point, not a conclusion.** The path from detection to action requires:
+
+**1. Contextualization:** What else was happening when the anomaly occurred? Recent operator actions, setpoint changes, upstream disturbances, weather, feed quality changes. A model can flag; only context can explain.
+
+**2. Triangulation:** Does the anomaly make physical sense? If the model says the reactor temperature is anomalous, check: Is the feed rate anomalous too? Is the coolant flow consistent? Are adjacent reactors showing similar patterns? An anomaly corroborated by multiple independent measurements is more credible than one resting on a single tag.
+
+**3. Severity estimation:** Not all anomalies are equally urgent. Map the anomaly score to a business-relevant metric when possible: estimated cost of continued operation, distance from a safety limit, remaining time before a trip limit is reached.
+
+**4. Recommended action:** The most valuable anomaly detection systems don't just say "anomalous" — they suggest actions:
+- "Heat exchanger HX-101 fouling rate has increased. Estimated time to minimum approach temperature: 3 weeks. Consider scheduling cleaning during next planned downtime."
+- "Compressor C-201 discharge temperature is \(5\,^{\circ}\mathrm{C}\) above expected. Pattern matches historical cases of suction strainer plugging. Recommend checking differential pressure across suction strainer."
+
+This requires combining the statistical model with domain knowledge — either encoded as rules, as a lookup against historical similar events, or provided by engineering SMEs who review the model's output.
+
+**5. Tracking outcomes:** When an alert is generated and acted upon, record the outcome. Was there actually a problem? What was it? How much time did early detection save? This closes the loop: it provides labels for model improvement, builds the business case for continued investment, and — critically — demonstrates value to operators and management.
+
+---
+
+*End of Phase 5. Key takeaway: The technical methods from Phases 1–4 are necessary but not sufficient. Successful industrial deployment requires clean data, regime segmentation, alarm rationalization, false positive management, retraining discipline, and — above all — the ability to translate statistical anomalies into operator-actionable insights. The best anomaly detection model in the world is worthless if operators don't trust it or can't act on it.*
+
+---
+
+# Quick Reference: Method Selection Guide
+
+| Situation | Start With | Consider Next |
+|-----------|-----------|---------------|
+| Single tag, slow drift | Exponential smoothing residuals | CUSUM, Holt-Winters |
+| Single tag, pattern anomaly | Matrix profile | ARIMA residuals |
+| Multivariate, correlated tags | PCA ($T^2$ / $Q$) | Multivariate autoencoder |
+| Known failure signature | Supervised classifier (if enough examples) | Template matching |
+| No idea what to look for | Isolation forest on windowed features | Matrix profile discords |
+| Need physics interpretability | First-principles health indicator (e.g., $U$ factor) | Residual from physics model |
+| Real-time monitoring | CUSUM, rolling z-score, online PCA | BOCPD |
+| Historical investigation | PELT change-point, matrix profile | Full batch PCA |
+
+---
+
+# Glossary
+
+| Term | Definition |
+|------|-----------|
+| **ACF** | Autocorrelation function — correlation of a series with its lagged self |
+| **ADF test** | Augmented Dickey-Fuller — tests for unit root (non-stationarity) |
+| **ARIMA** | AutoRegressive Integrated Moving Average — models autocorrelation structure |
+| **BOCPD** | Bayesian Online Change-Point Detection |
+| **Contribution plot** | Shows which variables drive a multivariate anomaly score |
+| **CUSUM** | Cumulative Sum — detects sustained small shifts in mean |
+| **Discord** | Matrix profile term — a subsequence with no good match (anomalous pattern) |
+| **Innovation** | Kalman filter term — the prediction error, expected to be white noise |
+| **KPSS test** | Kwiatkowski-Phillips-Schmidt-Shin — tests null of stationarity |
+| **LOF** | Local Outlier Factor — density-based anomaly detection |
+| **MAD** | Median Absolute Deviation — robust alternative to standard deviation |
+| **Matrix profile** | Nearest-neighbor distance for every subsequence in a time series |
+| **Motif** | Matrix profile term — a recurring pattern (subsequence with a very close match) |
+| **MSPC** | Multivariate Statistical Process Control (PCA-based monitoring) |
+| **PACF** | Partial autocorrelation function — direct correlation at each lag |
+| **PCA** | Principal Component Analysis |
+| **PELT** | Pruned Exact Linear Time — optimal offline change-point detection |
+| **PSD** | Power Spectral Density — variance at each frequency |
+| **$Q$ statistic / SPE** | Squared Prediction Error — distance from PCA model space |
+| **STL** | Seasonal-Trend decomposition using LOESS |
+| **$T^2$ (Hotelling's)** | Mahalanobis distance in PCA model space |

--- a/vendors/README.md
+++ b/vendors/README.md
@@ -1,0 +1,9 @@
+# Vendors
+
+Notes on specific vendor platforms: how they work, what their primitives are, and how their pieces fit together. Product-specific by nature, so they live here rather than in the general-purpose guides.
+
+| Directory | What's in it |
+|-----------|-------------|
+| `databricks/` | Data-side concepts glossary, Delta Tables vs Lakebase, curated external reading list |
+
+Keep these free of environment-specific detail. No workspace names, host URLs, cluster IDs, catalog names, or account paths, so notes stay portable and safe to share.

--- a/vendors/databricks/data-concepts.md
+++ b/vendors/databricks/data-concepts.md
@@ -1,0 +1,16 @@
+# Databricks — data concepts
+
+Running glossary of Databricks data-side concepts (storage layout, catalog conventions, table formats, lakehouse vocabulary). Add new sections as you encounter them.
+
+## Medallion architecture
+
+Standard Databricks layering for catalog/schema organisation. You'll see the layer name as a suffix on catalogs (e.g. `…_bronze`, `…_silver`).
+
+| Layer | Purpose | What you'll find |
+|---|---|---|
+| **bronze** | Raw ingestion, schema-on-read, minimal transformation | Raw historian / source-system dumps; rows often carry a `Properties.file_path` pointing at the source CSV/JSON |
+| **silver** | Cleaned, conformed, deduplicated, type-cast, joined to dimensions | Lab data, mode flags, trip-tagged windows — the "trusted" layer most analytics reads from |
+| **gold** | Business-aggregated, per-KPI | Final analytical tables; one table per KPI / dashboard / model-input |
+| **research** | Experimental / ad-hoc transforms; not always production-grade | First-cut feature engineering; data-scientist sandbox. Not always present, not promoted |
+
+Higher layers read from lower ones; never the reverse. A naive read against `bronze` will hit duplicates, non-`Good`-status rows, and unconformed schemas — that's the layer's job.

--- a/vendors/databricks/deltatables-vs-lakebase.md
+++ b/vendors/databricks/deltatables-vs-lakebase.md
@@ -1,0 +1,73 @@
+# Delta Tables vs Lakebase in Databricks
+
+## Overview
+
+Delta Tables and Lakebase are complementary components of the Databricks platform. Delta Tables handle large-scale analytics (OLAP), while Lakebase provides a transactional database for applications and AI agents (OLTP). Both are governed by Unity Catalog.
+
+## Delta Tables
+
+Delta Tables use the Delta Lake format (Parquet files + a transaction log) stored on cloud object storage (S3, ADLS, GCS). They are designed for analytical workloads: querying and transforming large datasets, running ETL pipelines, powering dashboards, and supporting machine learning.
+
+- **Latency:** seconds to minutes per query
+- **Scale:** petabyte-scale
+- **Query pattern:** aggregations, joins, and scans over large datasets
+- **Typical user:** data engineers, analysts, data scientists
+- **Storage:** cloud object storage
+
+## Lakebase
+
+Lakebase is a fully managed, serverless PostgreSQL database built into the Databricks platform. It is designed for operational workloads: serving AI agents, powering web applications, and handling high-frequency reads and writes on individual records.
+
+- **Latency:** milliseconds per operation
+- **Scale:** up to 2 TB per instance; 1,000 concurrent connections
+- **Query pattern:** single-row inserts, updates, and lookups
+- **Typical user:** application developers, AI agents
+- **Storage:** managed Postgres storage engine
+
+## Key Differences
+
+| Dimension         | Delta Tables                    | Lakebase                          |
+| ----------------- | ------------------------------- | --------------------------------- |
+| Workload type     | OLAP (analytics)                | OLTP (transactional)              |
+| Latency           | Seconds to minutes              | Milliseconds                      |
+| Storage backend   | Cloud object storage            | Managed Postgres                  |
+| Max data size     | Petabyte-scale                  | 2 TB per instance                 |
+| Query style       | Batch aggregations and scans    | Single-row reads and writes       |
+| Primary audience  | Data engineers and analysts     | App developers and AI agents      |
+| Wire protocol     | Spark / SQL Warehouse           | Standard Postgres (psycopg2, etc.)|
+
+## How They Work Together
+
+Lakebase's **Synced Tables** feature automatically mirrors Delta Tables into Lakebase, so analytical data built in pipelines can be served to applications at low latency without a separate ETL process. Both systems share Unity Catalog for unified governance, access control, and data lineage.
+
+In short: Delta Tables are the analytical backbone; Lakebase is the operational database layer: and they are designed to be used side by side.
+
+---
+
+## Appendix: Key Terms Explained
+
+**Database**: A system for storing, organising, and retrieving data. Think of it like a very powerful, structured spreadsheet that can hold millions or billions of rows and let many people (or applications) read and update data at the same time.
+
+**OLAP (Online Analytical Processing)**: A style of database work focused on answering big-picture questions: "What were total sales last quarter?", "Which region grew fastest?" These queries scan huge amounts of data to produce summaries, charts, and reports. Speed per individual record matters less than the ability to crunch large volumes.
+
+**OLTP (Online Transactional Processing)**: A style of database work focused on fast, small operations: "Add this item to the customer's cart", "Update the user's address", "Record this payment." Each operation touches one or a few rows, but it needs to happen in milliseconds because a real user or application is waiting for the result.
+
+**Transactional**: Describes a system that guarantees each operation either fully succeeds or fully fails, with nothing left in a half-finished state. If you transfer money between two bank accounts, a transactional system ensures the debit and credit both happen: or neither does. This property is often summarised by the acronym ACID (Atomicity, Consistency, Isolation, Durability).
+
+**Latency**: The time it takes for a system to respond to a request. Low latency (milliseconds) means fast responses, which is essential for apps and agents. Higher latency (seconds to minutes) is acceptable when running large analytical queries.
+
+**ETL (Extract, Transform, Load)**: The process of pulling data out of one system, cleaning or reshaping it, and loading it into another. For example, extracting sales records from a web app's database, calculating daily totals, and loading the results into an analytics platform.
+
+### Storage Formats
+
+**Delta Lake format (Parquet + transaction log)**: The file format used by Delta Tables. Data is stored in Parquet files, which are columnar (optimised for reading specific columns across many rows very quickly). Alongside the data sits a transaction log that tracks every change, enabling features like time-travel (querying data as it looked yesterday) and reliable concurrent writes. These files live on cloud object storage: essentially folders of files in services like Amazon S3, Azure Data Lake Storage, or Google Cloud Storage.
+
+**PostgreSQL (Postgres)**: A widely-used, open-source relational database that has been around since the 1980s. It stores data in traditional rows and tables and is optimised for fast, transactional operations: reading and writing individual records quickly. Lakebase is built on PostgreSQL, which means any tool, library, or programming language that already knows how to talk to Postgres can connect to Lakebase without changes. Think of Parquet/Delta Lake as the format built for scanning warehouses of data, and PostgreSQL as the engine built for serving one customer at a time, very quickly.
+
+### Other Terms
+
+**Unity Catalog**: Databricks' governance layer. It acts as a central directory that knows about every table, file, model, and user permission across the platform, so security rules and data lineage are managed in one place rather than separately for each tool.
+
+**Synced Tables**: A Databricks feature that automatically copies data from a Delta Table into a Lakebase Postgres table and keeps it up to date. This lets analytical data become instantly available to apps and agents without building a separate pipeline.
+
+**Cloud object storage**: File storage services provided by cloud platforms (Amazon S3, Azure Data Lake Storage, Google Cloud Storage). They can hold virtually unlimited amounts of data at low cost, but reading individual small records from them is slower than reading from a traditional database.

--- a/vendors/databricks/links.md
+++ b/vendors/databricks/links.md
@@ -1,0 +1,26 @@
+# Databricks — external links
+
+Curated reading list for Databricks reference material.
+
+## Getting started
+
+- [Getting Started with Databricks: A Beginner's Guide](https://medium.com/@mariusz_kujawski/getting-started-with-databricks-a-beginners-guide-8b8db7f6f457) — Mariusz Kujawski. Workspace / Notebooks / Cluster / Metastore primer; cluster types and access modes; Unity Catalog volumes; Delta Lake basics; PySpark reads.
+
+## Unity Catalog & MLflow
+
+- [Lessons learned from migrating models to Unity Catalog](https://medium.com/marvelous-mlops/lessons-learned-from-migrating-models-to-unity-catalog-5cc5b8a973eb) — Marvelous MLOps. 3-catalog (Dev/Staging/Prod) pattern, manual approval via external CI/CD (no UC webhooks), signature enforcement, `search_registered_models()` tag-filter limitations.
+
+## Forecasting
+
+- [A Framework for Multi-Model Forecasting on Databricks](https://www.databricks.com/blog/framework-multi-model-forecasting-databricks) — Databricks Blog. MMF framework: parallel multi-model training on Databricks clusters; standardized `evaluation_output` / `scoring_output` Unity Catalog tables; MLflow + Mosaic AI integration; Model Serving deployment.
+
+## Official docs
+
+- [Databricks Remote Development (SSH tunnel)](https://docs.databricks.com/aws/en/dev-tools/ssh-tunnel)
+- [MLOps workflows on Databricks](https://docs.databricks.com/en/machine-learning/mlops/mlops-workflow.html)
+- [Manage model lifecycle in Unity Catalog](https://docs.databricks.com/en/machine-learning/manage-model-lifecycle/index.html)
+- [AI and machine learning on Databricks](https://docs.databricks.com/aws/en/machine-learning/) — Overview of the integrated platform for building, training, deploying, and managing AI/ML applications across the full lifecycle.
+- [What are Unity Catalog volumes?](https://docs.databricks.com/aws/en/volumes) — Unity Catalog objects for governing non-tabular datasets; covers managed vs. external storage types and access control.
+- [Databricks architecture](https://docs.databricks.com/aws/en/getting-started/architecture) — Control plane vs. compute plane, lakehouse design patterns (medallion architecture), and ACID guarantees.
+- [Connect to serverless compute](https://docs.databricks.com/aws/en/compute/serverless/) — How to configure and use serverless compute for notebooks, workflows, and Lakeflow Spark Declarative Pipelines on AWS.
+- [CI/CD on Databricks](https://docs.databricks.com/aws/en/dev-tools/ci-cd/) — CI/CD approaches on Databricks including Declarative Automation Bundles and other pipeline tooling for data engineering and data science.


### PR DESCRIPTION
## Summary

Brings over the shareable subset of a personal docs folder so the handbook becomes the single canonical home for these notes.

## What's included

- **`vendors/databricks/`** — data concepts glossary, Delta Tables vs Lakebase comparison, curated external reading list
- **`reading-list/`** — knowledge-graphs, llm-inference, edge-ml topic guides
- **`ml-guides/`** — gradient-boosted trees and neural additive model reference notes (restructured from phased study guides into concept-organised notes), plus tabular-data and ai-gateway-vs-router
- **`time-series/anomaly-detection/`** — anomaly detection guide, placed next to the Kalman filter code it refers to
- **`dev-tips/`** — `github.md` (gh permissions, PR vs draft PR) and `cursor-settings-transfer.md`

Diagrams are inline SVGs under per-topic `images/` directories.

## Scrubbing

Company, client, and environment-specific material was excluded or scrubbed: no workspace names, host URLs, cluster IDs, account paths, internal repo names, or client-engagement content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)